### PR TITLE
Add Classes & Other Selectors for elementHandledElsewhere()

### DIFF
--- a/jspdf.plugin.from_html.js
+++ b/jspdf.plugin.from_html.js
@@ -475,26 +475,39 @@ function executeHandlers( isHandledElsewhere, handlers, element, renderer ) {
 function elementHandledElsewhere(element, renderer, elementHandlers){
 	var isHandledElsewhere = false
 	, classNames = element.className
-		
+	
+	// Handle IDs
 	var handlers = elementHandlers['#'+element.id]
-	if (handlers) {
+	if (!isHandledElsewhere && handlers) {
 		isHandledElsewhere = executeHandlers( isHandledElsewhere, handlers, element, renderer )
 	}
 	
+	// Handle Class Names
 	handlers = []
 	classNames = classNames.split(" ");
 	$.each(classNames, function() {
 		handlers.push(elementHandlers['.'+this])
 	});
-	if (handlers) {
+	if (!isHandledElsewhere && handlers) {
 		isHandledElsewhere = executeHandlers( isHandledElsewhere, handlers, element, renderer )
 	}
-
+	
+	// Handle nodeNames (e.g., div)
 	handlers = elementHandlers[element.nodeName]
-	if (handlers) {
+	if (!isHandledElsewhere && handlers) {
 		isHandledElsewhere = executeHandlers( isHandledElsewhere, handlers, element, renderer )
 	}
-
+	
+	// Handle "other" types of selectors
+	handlers =  Object.keys(elementHandlers)
+	if (!isHandledElsewhere && handlers) {
+		$.each(handlers, function(index, key) {
+			var selector = $(element).filter(key).val()
+			if ( $(element).filter(key).length > 0 &&  typeof key !== 'function')
+				isHandledElsewhere =  true
+		});
+	}
+	
 	return isHandledElsewhere
 }
 

--- a/jspdf.plugin.from_html.js
+++ b/jspdf.plugin.from_html.js
@@ -451,25 +451,8 @@ function GetCSS(element){
 	return css
 }
 
-function elementHandledElsewhere(element, renderer, elementHandlers){
-	var isHandledElsewhere = false
-
-	var i, l, t
-	, handlers = elementHandlers['#'+element.id]
-	if (handlers) {
-		if (typeof handlers === 'function') {
-			isHandledElsewhere = handlers(element, renderer)
-		} else /* array */ {
-			i = 0
-			l = handlers.length
-			while (!isHandledElsewhere && i !== l){
-				isHandledElsewhere = handlers[i](element, renderer)
-				;i++;
-			}
-		}
-	}
-
-	handlers = elementHandlers[element.nodeName]
+function executeHandlers( isHandledElsewhere, handlers, element, renderer ) {
+	var i, l
 	if (!isHandledElsewhere && handlers) {
 		if (typeof handlers === 'function') {
 			isHandledElsewhere = handlers(element, renderer)
@@ -477,10 +460,39 @@ function elementHandledElsewhere(element, renderer, elementHandlers){
 			i = 0
 			l = handlers.length
 			while (!isHandledElsewhere && i !== l){
-				isHandledElsewhere = handlers[i](element, renderer)
+				if (typeof handlers[i] === 'function') {
+					isHandledElsewhere = handlers[i](element, renderer)
+				}
 				;i++;
 			}
 		}
+	}
+	
+	
+	return isHandledElsewhere
+}
+
+function elementHandledElsewhere(element, renderer, elementHandlers){
+	var isHandledElsewhere = false
+	, classNames = element.className
+		
+	var handlers = elementHandlers['#'+element.id]
+	if (handlers) {
+		isHandledElsewhere = executeHandlers( isHandledElsewhere, handlers, element, renderer )
+	}
+	
+	handlers = []
+	classNames = classNames.split(" ");
+	$.each(classNames, function() {
+		handlers.push(elementHandlers['.'+this])
+	});
+	if (handlers) {
+		isHandledElsewhere = executeHandlers( isHandledElsewhere, handlers, element, renderer )
+	}
+
+	handlers = elementHandlers[element.nodeName]
+	if (handlers) {
+		isHandledElsewhere = executeHandlers( isHandledElsewhere, handlers, element, renderer )
 	}
 
 	return isHandledElsewhere


### PR DESCRIPTION
There was redundant code within `elementHandledElsewhere()` so I refactored it to `executeHandlers()` and added class names as a handler to `elementHandledElsewhere()`.

If we follow the No Selector ID rule in CSS (as well as the notion that IDs are to identify a single element), it makes much more sense to have a `.bypass` class option available to users.

Also added other selectors as a possibility (e.g., div[id^="bypass-"]). This will ignore the function side. 

So the addictions can be used as such:

```javascript
specialElementHandlers = {
	// element with class of "bypass" - jQuery style selector
	'div[id^="bypass-"]': true,
	'.bypass': function(element, renderer){
		console.log('.bypass');
		// true = "handled elsewhere, bypass text extraction"
		return true
	}
}
```