### PR TITLE
Basic Example broken

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -10,8 +10,9 @@
 	<script type="text/javascript" src="js/jquery/jquery-1.7.1.min.js"></script>
 	<script type="text/javascript" src="js/jquery/jquery-ui-1.8.17.custom.min.js"></script>
 	<script type="text/javascript" src="../jspdf.js"></script>
+	<script type="text/javascript" src="../libs/Deflate/adler32cs.js"></script>
 	<script type="text/javascript" src="../libs/FileSaver.js/FileSaver.js"></script>
-	<script type="text/javascript" src="../libs/BlobBuilder.js/BlobBuilder.js"></script>
+	<script type="text/javascript" src="../libs/Blob.js/BlobBuilder.js"></script>
 
 	<script type="text/javascript" src="../jspdf.plugin.addimage.js"></script>
 


### PR DESCRIPTION
Basic example broken when project was switched to use Deflate. [adler32cs.js](https://github.com/MrRio/jsPDF/blob/master/libs/Deflate/adler32cs.js) is now a dependency.
