### PR TITLE
introduce auto print

### DIFF
--- a/jspdf.plugin.autoprint.js
+++ b/jspdf.plugin.autoprint.js
@@ -1,0 +1,29 @@
+(function(jsPDFAPI) {
+'use strict'
+
+jsPDFAPI.autoPrint = function() {
+  'use strict'
+  // `this` is _jsPDF object returned when jsPDF is inited (new jsPDF())
+  // `this.internal` is a collection of useful, specific-to-raw-PDF-stream functions.
+  // for example, `this.internal.write` function allowing you to write directly to PDF stream.
+  // `this.line`, `this.text` etc are available directly.
+  // so if your plugin just wraps complex series of this.line or this.text or other public API calls,
+  // you don't need to look into `this.internal`
+  // See _jsPDF object in jspdf.js for complete list of what's available to you.
+  var refAutoPrintTag;
+
+  this.internal.events.subscribe('postPutResources', function(){
+    refAutoPrintTag = this.internal.newObject()
+    this.internal.write("<< /S/Named /Type/Action /N/Print >>", "endobj");
+  })
+
+  this.internal.events.subscribe("putCatalog", function(){
+    this.internal.write("/OpenAction " + refAutoPrintTag + " 0" + " R");
+  });
+
+  // it is good practice to return ref to jsPDF instance to make
+  // the calls chainable.
+  return this;
+}
+
+})(jsPDF.API)


### PR DESCRIPTION
Hi, 
I needed an auto print feature for my PDF. I tried many things :
- including iframe tricks [printing an overview of the webpage]
- jspdf.plugin.javascript with a call to this.print() [compatible acrobat reader only]

So you'll find a basic plugin. It needs some refinements (test/doc) but I wanted to check if you are interested. 

The basic idea for the auto printing is  

```
var doc = new jsPDF();
doc.text(20, 20, 'Hello world.');
doc.autoPrint()
doc.output("dataurlnewwindow") // so it open a new popup,  after this the PDF open the print window view. You can save the pdf and when opened, it display the print settings view.
```

Let me know what you need to merge.
