### PR TITLE
Added plenty of standard paper formats

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -32,7 +32,7 @@ Creates new jsPDF document object instance
 @class
 @param orientation One of "portrait" or "landscape" (or shortcuts "p" (Default), "l")
 @param unit Measurement unit to be used when coordinates are specified. One of "pt" (points), "mm" (Default), "cm", "in"
-@param format One of 'a3', 'a4' (Default),'a5' ,'letter' ,'legal'
+@param format One of 'a0', 'a1', 'a2', 'a3', 'a4' (Default) etc to 'a10', 'b0' to 'b10', 'c0' to 'c10', 'letter', 'government-letter', 'legal', 'junior-legal', 'ledger' or 'tabloid'
 @returns {jsPDF}
 @name jsPDF
 */
@@ -344,11 +344,45 @@ PubSub implementation
             compress = compressPdf,
             pdfVersion = '1.3', // PDF Version
             pageFormats = { // Size in pt of various paper formats
-                'a3': [841.89, 1190.55],
-                'a4': [595.28, 841.89],
-                'a5': [420.94, 595.28],
+                'a0': [2383.94, 3370.39],
+                'a1': [1683.78, 2383.94],
+                'a2': [1190.55, 1683.78],
+                'a3': [841.89,  1190.55],
+                'a4': [595.28,  841.89],
+                'a5': [419.53,  595.28],
+                'a6': [297.64,  419.53],
+                'a7': [209.76,  297.64],
+                'a8': [147.4 ,  209.76],
+                'a9': [104.88,  147.4],
+                'a10': [73.7,  104.88],
+                'b0': [2834.65, 4008.19],
+                'b1': [2004.09, 2834.65],
+                'b2': [1417.32, 2004.09],
+                'b3': [1000.63, 1417.32],
+                'b4': [708.66,  1000.63],
+                'b5': [498.9,  708.66],
+                'b6': [354.33,  498.9],
+                'b7': [249.45,  354.33],
+                'b8': [175.75,  249.45],
+                'b9': [124.72,  175.75],
+                'b10': [87.87,  124.72],
+                'c0': [2599.37, 3676.54],
+                'c1': [1836.85, 2599.37],
+                'c2': [1298.27, 1836.85],
+                'c3': [918.43,  1298.27],
+                'c4': [649.13,  918.43],
+                'c5': [459.21,  649.13],
+                'c6': [323.15,  459.21],
+                'c7': [229.61,  323.15],
+                'c8': [161.57,  229.61],
+                'c9': [113.39,  161.57],
+                'c10': [79.37,   113.39],
                 'letter': [612, 792],
-                'legal': [612, 1008]
+                'government-letter': [576, 756],
+                'legal': [612, 1008],
+                'junior-legal': [576, 360],
+                'ledger': [1224, 792],
+                'tabloid': [792, 1224]
             },
             textColor = '0 g',
             drawColor = '0 G',


### PR DESCRIPTION
Page formats now available: a0-a10,, b0-b10, c0, c10 and US formats
;etter, government letter, legal, junior legal, ledger and tabloid.
