### PR TITLE
Global variables accidentally created in basic demo

### DIFF
--- a/examples/js/basic.js
+++ b/examples/js/basic.js
@@ -309,17 +309,17 @@ function demoStringSplitting() {
 }
 
 function demoFromHTML() {
-	var pdf = new jsPDF('p', 'in', 'letter');
+	var pdf = new jsPDF('p', 'in', 'letter')
 
 	// source can be HTML-formatted string, or a reference
 	// to an actual DOM element from which the text will be scraped.
-	source = $('#fromHTMLtestdiv')[0]
+	, source = $('#fromHTMLtestdiv')[0]
 
 	// we support special element handlers. Register them with jQuery-style 
 	// ID selector for either ID or node name. ("#iAmID", "div", "span" etc.)
 	// There is no support for any other type of selectors 
 	// (class, of compound) at this time.
-	specialElementHandlers = {
+	, specialElementHandlers = {
 		// element with id of "bypass" - jQuery style selector
 		'#bypassme': function(element, renderer){
 			// true = "handled elsewhere, bypass text extraction"


### PR DESCRIPTION
I came across a syntax error in the downloaded version. Looks like it's been fixed in the repo, but not quite in the correct way.
