### PR TITLE
Fix the names of the join styles.

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1766,7 +1766,7 @@ PubSub implementation
             0: 0,
             'butt': 0,
             'but': 0,
-            'bevel': 0,
+            'miter': 0,
             1: 1,
             'round': 1,
             'rounded': 1,
@@ -1775,7 +1775,7 @@ PubSub implementation
             'projecting': 2,
             'project': 2,
             'square': 2,
-            'milter': 2
+            'bevel': 2
         };
 
         /**


### PR DESCRIPTION
'miter' was spelled incorrectly ('milter'), and it was swapped with 'bevel'.
Join style 0 is 'miter', and join style 2 is 'bevel'.

See, for example,
    http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/JointStyle.html
or
    http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/cap-join-styles.html
for examples of the 'miter' and 'bevel' join styles.
