### PR TITLE
Reuse previously added images

### DIFF
--- a/jspdf.plugin.addimage.js
+++ b/jspdf.plugin.addimage.js
@@ -54,7 +54,7 @@ var getImageCollections = function () {
 		}
 
 		return { 'index': imageIndex, 'images': images, 'namedImages': namedImages };
-},
+}
 // takes a string imgData containing the raw bytes of
 // a jpeg image and returns [width, height]
 // Algorithm from: http://www.64lines.com/jpeg-width-height


### PR DESCRIPTION
Hello, I added in support for reusing images that have already been added into the PDF, per issue https://github.com/MrRio/jsPDF/issues/99. I tried to follow the style conventions I noticed in the plugin already, but if I've done anything you don't like, feel free to clean up or tell me how to clean it up. :)

The new functionality can be used in the way suggested by n8v:

doc.addImage(imgData, 'JPEG', 15, 40, 180, 180, 'Octonyan');
doc.addImage('Octonyan', 'JPEG', 15, 400, 180, 180);
