### PR TITLE
Updated reference to live editor & examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ doc.text(20, 20, 'Hello world.');
 doc.save('Test.pdf');
 ```
 
-### Head over to [jsPDF.com](http://jspdf.com) for the live editor and examples
+### Head over to [jsPDF.com](http://jspdf.com) for details or [http://mrrio.github.io/jsPDF/](mrrio.github.io/jsPDF/) for a live editor and examples.
 
 ## Checking out the source
 


### PR DESCRIPTION
jspdf.com doesn't provide an easy way to get to the live editor mentioned in README's text. This patch add a direct link to the live editor.
