### PR TITLE
Allow style setting postponement for all drawing methods + direct use of select path-painting operators

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1012,7 +1012,7 @@ var jsPDF = (function(global) {
 		 * @param {Number} x Coordinate (in units declared at inception of PDF document) against left edge of the page
 		 * @param {Number} y Coordinate (in units declared at inception of PDF document) against upper edge of the page
 		 * @param {Number} scale (Defaults to [1.0,1.0]) x,y Scaling factor for all vectors. Elements can be any floating number Sub-one makes drawing smaller. Over-one grows the drawing. Negative flips the direction.
-		 * @param {String} style One of 'S' (the default), 'F', 'FD', 'DF' or null.  'S' draws just the curve. 'F' fills the region defined by the curves. 'DF' or 'FD' draws the curves and fills the region. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
+		 * @param {String} style A string specifying the painting style or null.  Valid styles include: 'S' [default] - stroke, 'F' - fill,  and 'DF' (or 'FD') -  fill then stroke. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
 		 * @param {Boolean} closed If true, the path is closed with a straight line from the end of the last curve to the starting point.
 		 * @function
 		 * @returns {jsPDF}
@@ -1091,7 +1091,7 @@ var jsPDF = (function(global) {
 		 * @param {Number} y Coordinate (in units declared at inception of PDF document) against upper edge of the page
 		 * @param {Number} w Width (in units declared at inception of PDF document)
 		 * @param {Number} h Height (in units declared at inception of PDF document)
-		 * @param {String} style (Defaults to active fill/stroke style) A string signalling if stroke, fill or both are to be applied.
+		 * @param {String} style A string specifying the painting style or null.  Valid styles include: 'S' [default] - stroke, 'F' - fill,  and 'DF' (or 'FD') -  fill then stroke. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
 		 * @function
 		 * @returns {jsPDF}
 		 * @methodOf jsPDF#
@@ -1123,7 +1123,7 @@ var jsPDF = (function(global) {
 		 * @param {Number} y2 Coordinate (in units declared at inception of PDF document) against upper edge of the page
 		 * @param {Number} x3 Coordinate (in units declared at inception of PDF document) against left edge of the page
 		 * @param {Number} y3 Coordinate (in units declared at inception of PDF document) against upper edge of the page
-		 * @param {String} style (Defaults to active fill/stroke style) A string signalling if stroke, fill or both are to be applied.
+		 * @param {String} style A string specifying the painting style or null.  Valid styles include: 'S' [default] - stroke, 'F' - fill,  and 'DF' (or 'FD') -  fill then stroke. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
 		 * @function
 		 * @returns {jsPDF}
 		 * @methodOf jsPDF#
@@ -1153,7 +1153,7 @@ var jsPDF = (function(global) {
 		 * @param {Number} h Height (in units declared at inception of PDF document)
 		 * @param {Number} rx Radius along x axis (in units declared at inception of PDF document)
 		 * @param {Number} rx Radius along y axis (in units declared at inception of PDF document)
-		 * @param {String} style (Defaults to active fill/stroke style) A string signalling if stroke, fill or both are to be applied.
+		 * @param {String} style A string specifying the painting style or null.  Valid styles include: 'S' [default] - stroke, 'F' - fill,  and 'DF' (or 'FD') -  fill then stroke. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
 		 * @function
 		 * @returns {jsPDF}
 		 * @methodOf jsPDF#
@@ -1186,7 +1186,7 @@ var jsPDF = (function(global) {
 		 * @param {Number} y Coordinate (in units declared at inception of PDF document) against upper edge of the page
 		 * @param {Number} rx Radius along x axis (in units declared at inception of PDF document)
 		 * @param {Number} rx Radius along y axis (in units declared at inception of PDF document)
-		 * @param {String} style (Defaults to active fill/stroke style) A string signalling if stroke, fill or both are to be applied.
+		 * @param {String} style A string specifying the painting style or null.  Valid styles include: 'S' [default] - stroke, 'F' - fill,  and 'DF' (or 'FD') -  fill then stroke. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
 		 * @function
 		 * @returns {jsPDF}
 		 * @methodOf jsPDF#
@@ -1249,7 +1249,7 @@ var jsPDF = (function(global) {
 		 * @param {Number} x Coordinate (in units declared at inception of PDF document) against left edge of the page
 		 * @param {Number} y Coordinate (in units declared at inception of PDF document) against upper edge of the page
 		 * @param {Number} r Radius (in units declared at inception of PDF document)
-		 * @param {String} style (Defaults to active fill/stroke style) A string signalling if stroke, fill or both are to be applied.
+		 * @param {String} style A string specifying the painting style or null.  Valid styles include: 'S' [default] - stroke, 'F' - fill,  and 'DF' (or 'FD') -  fill then stroke. A null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument.
 		 * @function
 		 * @returns {jsPDF}
 		 * @methodOf jsPDF#


### PR DESCRIPTION
With this patch, the option to defer style setting implemented for lines() by https://github.com/MrRio/jsPDF/pull/203 is now available when calling all drawing methods. 

This patch makes it possible to use nested shapes to cut holes in paths, including allowing control of the ruleset used to determine which regions to fill. The latter functionality is implemented by permitting direct use of select PDF path-painting operators. 
## Example

```
var pdf = new jsPDF("portrait", "mm", "letter");
pdf.rect(125, 25, 50, 50, null);
pdf.rect(105, 5, 95, 95, 'f*'); 

pdf.ellipse(55, 30, 5, 5, null);
pdf.ellipse(40, 20, 30, 20, 'f*');
```

Outputs:
![endresult](https://f.cloud.github.com/assets/857202/2401628/46380b42-aa18-11e3-9a58-d6cda7e11ff0.png)

Without this patch, the above code would output:
![prepatch](https://f.cloud.github.com/assets/857202/2401679/cc45460a-aa18-11e3-8529-2a80f4b8c043.png)
