### PR TITLE
Cross browsing compatibility getTextDimension()

### DIFF
--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -66,7 +66,7 @@
         text.style.fontStyle = fontStyle;
         text.style.fontName = fontName;
         text.style.fontSize = fontSize + 'pt';
-        text.innerText = txt;
+        text.innerHTML = txt;
 
         document.body.appendChild(text);
 


### PR DESCRIPTION
I have changed the innerText with the innerHTML for cross browsing compatibility. Firefox always retun 0 offsetwidth using innerText. With innerHtml, Chrome, Firefox and IE are working fine.
