### PR TITLE
change supportsArrayBuffer check to work with Safari

### DIFF
--- a/dist/jspdf.debug.js
+++ b/dist/jspdf.debug.js
@@ -2078,7 +2078,7 @@ var jsPDF = (function(global) {
 	 * Check to see if ArrayBuffer is supported
 	 */
 	jsPDFAPI.supportsArrayBuffer = function() {
-		return typeof ArrayBuffer === 'function' && typeof Uint8Array !== 'undefined';
+		return typeof ArrayBuffer !== 'undefined' && typeof Uint8Array !== 'undefined';
 	};
 
 	/**


### PR DESCRIPTION
Safari reports the type of ArrayBuffer as 'object' (sic). This fixes the support check for the ArrayBuffer class.
