### PR TITLE
Fixed default coordinates bug in fromHTML

### DIFF
--- a/jspdf.plugin.from_html.js
+++ b/jspdf.plugin.from_html.js
@@ -851,6 +851,13 @@
 			settings = {};
 		if (!settings.elementHandlers)
 			settings.elementHandlers = {};
-		return process(this, HTML, x || 4, y || 4, settings, callback);
+			
+		if (x === undefined)
+			x = 4;
+		
+		if (y === undefined)
+			y = 4;
+			
+		return process(this, HTML, x, y, settings, callback);
 	};
 })(jsPDF.API);


### PR DESCRIPTION
It seems there was no way to set starting coordinates to **0** using _fromHTML_ method,

When you specified x = 0 or y = 0, they defaulted to 4.

This was caused by following snippet from **jspdf.plugin.from_html.js**:

``` javascript
jsPDFAPI.fromHTML = function (HTML, x, y, settings, callback, margins) {
    // ...
    return process(this, HTML, x || 4, y || 4, settings, callback);
}
```

Now they default to **4**, only in case when their values are _undefined_.
