### PR TITLE
added getPageFormat and addPageFormat to jsPDF object

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1698,6 +1698,14 @@ var jsPDF = (function(global) {
 	 */
 	jsPDF.API = {events:[]};
 	jsPDF.version = "1.0.0-trunk";
+	
+	jsPDF.getPageFormat = function(fmt) {
+		return pageFormats[fmt];
+	}
+	jsPDF.addPageFormat = function(fmt, dim) {
+		pageFormats[fmt] = dim;
+	}
+
 
 	if (typeof define === 'function' && define.amd) {
 		define(function() {


### PR DESCRIPTION
I have a need to add my own page formats but couldn't figure out how to do that without modifying the jsPDF source. 

I also wasn't sure if I should add my functions to the jsPDF or jsPDF.API object. 

Thanks for the pdf generator. It cut my server load by quite a bit ;)
