### PR TITLE
requirejs patch for anonymous define()

### DIFF
--- a/dist/jspdf.debug.js
+++ b/dist/jspdf.debug.js
@@ -1700,7 +1700,7 @@ var jsPDF = (function(global) {
 	jsPDF.version = "1.0.178-debug 2014-06-27T15:34:diegocr";
 
 	if (typeof define === 'function' && define.amd) {
-		define(function() {
+		define('jsPDF', function() {
 			return jsPDF;
 		});
 	} else {

--- a/jspdf.js
+++ b/jspdf.js
@@ -1700,7 +1700,7 @@ var jsPDF = (function(global) {
 	jsPDF.version = "1.0.0-trunk";
 
 	if (typeof define === 'function' && define.amd) {
-		define(function() {
+		define('jsPDF', function() {
 			return jsPDF;
 		});
 	} else {


### PR DESCRIPTION
This is the patch for my posted issue at: https://github.com/MrRio/jsPDF/issues/309

---

I tried using **jsPDF** (.debug.js and .min.js) with **RequireJS** (2.1.11). Everything works fine until I use grunt to build my webapp. After minification, my webapp break with error:

![screenshot](https://cloud.githubusercontent.com/assets/1733015/3595683/1ae8b168-0cb9-11e4-9abd-2f13eff45171.png)

![screenshot-1](https://cloud.githubusercontent.com/assets/1733015/3595687/26afdd1e-0cb9-11e4-8cfa-1e4327a3fb26.png)

I found a workaround to this problem, by specifying what is called a stringID for that define() function:

``` javascript
define('jsPDF', function(){
    return jsPDF;
});
```
