### PR TITLE
Fixed issue with using .cell(....) and a new page being created, plus other minor changes.

### DIFF
--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -134,7 +134,8 @@
                     }
                 }
             } else {
-                this.text(txt, x + padding, y + this.internal.getLineHeight());
+                // Fix the next line to "vertically center" the row
+                this.text(txt, x + padding, y + (this.internal.getLineHeight() / 2));
             }
         }
         setLastCellPosition(x, y, w, h, ln);

--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -112,11 +112,11 @@
                         this.printHeaderRow(ln, true);
                     }
                 }
+                
                 //We ignore the passed y: the lines may have different heights
                 // (Added to fix problem with a new page having an 'undefined' value for 'h'. This
                 // fix prevents the 'y' value below from being Nan and restarts table at 'y' on page.)
                 y = (getLastCellPosition().y + (getLastCellPosition().h || y));
-
             }
         }
 
@@ -126,6 +126,7 @@
             } else {
                 this.rect(x, y, w, h);
             }
+            
             if (align === 'right') {
                 if (txt instanceof Array) {
                     for(var i = 0; i<txt.length; i++) {
@@ -135,9 +136,21 @@
                     }
                 }
             } else if (align === 'center') {
-                // Center the text in the cell
-                var textSize = (this.getStringUnitWidth(txt) * this.internal.getFontSize()) / this.internal.scaleFactor;
-                this.text(txt, x + ((w - textSize) / 2), y + (this.internal.getLineHeight() / 2));
+                var linesOfText;
+
+                // We want an array of text lines
+                if (txt instanceof Array) {
+                    linesOfText = txt;
+                } else {
+                    linesOfText = new Array(txt);
+                }
+
+                // Go through the lines of text and output them as requried
+                for (var i = 0; i < linesOfText.length; i++) {
+                    var currentLine = linesOfText[i];
+                    var textSize = (this.getStringUnitWidth(currentLine) * this.internal.getFontSize()) / this.internal.scaleFactor;
+                    this.text(currentLine, x + ((w - textSize) / 2), y + ((this.internal.getLineHeight() * (i + 1)) / 2));
+                }
             } else {
                 // Fix the next line to "vertically center" the row
                 this.text(txt, x + padding, y + (this.internal.getLineHeight() / 2));

--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -93,8 +93,9 @@
         pages = 1;
     };
 
-    jsPDFAPI.cell = function (x, y, w, h, txt, ln, align) {
+    jsPDFAPI.cell = function (x, y, w, h, txt, ln, align, fillRect) {
         var curCell = getLastCellPosition();
+        var fillRectangle = fillRect || false;
 
         // If this is not the first cell, we must change its position
         if (curCell.ln !== undefined) {
@@ -120,7 +121,7 @@
         }
 
         if (txt[0] !== undefined) {
-            if (this.printingHeaderRow) {
+            if (this.printingHeaderRow || fillRectangle) {
                 this.rect(x, y, w, h, 'FD');
             } else {
                 this.rect(x, y, w, h);

--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -134,6 +134,10 @@
                         this.text(currentLine, x + w - textSize - padding, y + this.internal.getLineHeight()*(i+1));
                     }
                 }
+            } else if (align === 'center') {
+                // Center the text in the cell
+                var textSize = (this.getStringUnitWidth(txt) * this.internal.getFontSize()) / this.internal.scaleFactor;
+                this.text(txt, x + ((w - textSize) / 2), y + (this.internal.getLineHeight() / 2));
             } else {
                 // Fix the next line to "vertically center" the row
                 this.text(txt, x + padding, y + (this.internal.getLineHeight() / 2));

--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -111,8 +111,10 @@
                         this.printHeaderRow(ln, true);
                     }
                 }
-                //We ignore the passed y: the lines may have diferent heights
-                y = (getLastCellPosition().y + getLastCellPosition().h);
+                //We ignore the passed y: the lines may have different heights
+                // (Added to fix problem with a new page having an 'undefined' value for 'h'. This
+                // fix prevents the 'y' value below from being Nan and restarts table at 'y' on page.)
+                y = (getLastCellPosition().y + (getLastCellPosition().h || y));
 
             }
         }


### PR DESCRIPTION
When a new page was created because of the document length causing a call to .addPage, the default value for 'h' was left as 'undefined'. That resulted in the new 'y' value being set to Nan. The resulting PDF had errors when it was opened. This is a fix for that issue. Now when a new page is created, the table will start at the initial y position as it did on the first page. This allows for any header information on the page to be preserved.

I also added code to vertically center the cell text, as it made it more appealing to the eye. I added code to force a cell to be filled (use setFillColor() to set the fill color). And finally I added code to implement simple centering in a cell. Use align='center' when calling .cell().
