### PR TITLE
Use more precise conversion factor for mm and cm

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -868,14 +868,14 @@ var jsPDF = (function(global) {
 		});
 
 		switch (unit) {
-			case 'pt':  k = 1;          break;
-			case 'mm':  k = 72 / 25.4;  break;
-			case 'cm':  k = 72 / 2.54;  break;
-			case 'in':  k = 72;         break;
-			case 'px':  k = 96 / 72;    break;
-			case 'pc':  k = 12;         break;
-			case 'em':  k = 12;         break;
-			case 'ex':  k = 6;          break;
+			case 'pt':  k = 1;                break;
+			case 'mm':  k = 72 / 25.4000508;  break;
+			case 'cm':  k = 72 / 2.54000508;  break;
+			case 'in':  k = 72;               break;
+			case 'px':  k = 96 / 72;          break;
+			case 'pc':  k = 12;               break;
+			case 'em':  k = 12;               break;
+			case 'ex':  k = 6;                break;
 			default:
 				throw ('Invalid unit: ' + unit);
 		}


### PR DESCRIPTION
With the simple conversion factor the width of DIN A4 will be 21.01 cm. With the corrected factor it is 21 cm. Source: http://de.wikipedia.org/wiki/Zoll_(Einheit)
