### PR TITLE
Update file 'bower.js' only if file 'bower' exists

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,10 @@ whoami=`whoami`
 git submodule foreach git pull origin master
 
 # Update Bower
-cat bower \
-	| sed "s/\"1\.0\.0\"/\"${version}\"/" >bower.json
+if [ -f bower ]; then
+  cat bower \
+    | sed "s/\"1\.0\.0\"/\"${version}\"/" >bower.json
+fi
 
 # Fix conflict with adler32 & FileSaver
 adler1="libs/adler32cs.js/adler32cs.js"


### PR DESCRIPTION
In build.sh the file bower.json is rewritten based on a template file 'bower' and the current date. The template file is not committed and doesn't exists after cloning the project so that bower.json will be empty after running build.sh.

Anyway, I'd prefer if the bower.json is not modified by running build.sh. The solution I provide is to check if the template file 'bower' exists. If it doesn't exists bower.json won't be rewritten.