### PR TITLE
Avoid style references on text values

### DIFF
--- a/jspdf.plugin.from_html.js
+++ b/jspdf.plugin.from_html.js
@@ -484,9 +484,10 @@
 							};
 						}
 					}
-					renderer.addText(value, fragmentCSS);
+                                        // A reference would later change the block style when the lines are split, causing an abnormal margin
+                                        renderer.addText(value, clone(fragmentCSS));
 				} else if (typeof cn === "string") {
-					renderer.addText(cn, fragmentCSS);
+                                        renderer.addText(cn, clone(fragmentCSS));
 				}
 			}
 			i++;


### PR DESCRIPTION
A case where a style reference will break the layout is of text that
belongs to a block parent, which in turn has a text-align css attribute
assigned to it (such as 'center').
Without a reference, the line split function would inadvertently modify
the block style during paragraph rendering

Sample html which causes the layout error:

``` html
<h1 style="text-align: center">Some text</h1>
```
