### PR TITLE
Deletepage fix

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -713,13 +713,15 @@ var jsPDF = (function(global) {
 			events.publish('addPage', { pageNumber : page });
 		},
 		_deletePage = function( n ) {
-			pages.splice(n, 1);
-			pagedim.splice(n, 1);
-			page--;
-			if (currentPage > page){
-				currentPage = page;
+			if (n > 0 && n <= page) {
+				pages.splice(n, 1);
+				pagedim.splice(n, 1);
+				page--;
+				if (currentPage > page){
+					currentPage = page;
+				}
+				this.setPage(currentPage);
 			}
-			this.setPage(currentPage);
 		},
 		_setPage = function(n) {
 			if (n > 0 && n <= page) {

--- a/jspdf.js
+++ b/jspdf.js
@@ -18,6 +18,7 @@
  *               2014 James Makes, https://github.com/dollaruw
  *               2014 Diego Casorran, https://github.com/diegocr
  *               2014 Steven Spungin, https://github.com/Flamenco
+ *               2014 Kenneth Glassey, https://github.com/Gavvers
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -711,6 +712,15 @@ var jsPDF = (function(global) {
 			}
 			events.publish('addPage', { pageNumber : page });
 		},
+		_deletePage = function( n ) {
+			pages.splice(n, 1);
+			pagedim.splice(n, 1);
+			page--;
+			if (currentPage > page){
+				currentPage = page;
+			}
+			this.setPage(currentPage);
+		},
 		_setPage = function(n) {
 			if (n > 0 && n <= page) {
 				currentPage = n;
@@ -1022,16 +1032,8 @@ var jsPDF = (function(global) {
 			}
 			return this;
 		};
-		API.deletePage = function(targetPage) {
-			for (var i=targetPage; i< page; i++){
-				pages[i] = pages[i+1];
-				pagedim[i] = pagedim[i+1];				
-			}
-			page--;
-			if (currentPage > page){
-				currentPage = page;
-			}
-			this.setPage(currentPage);
+		API.deletePage = function() {
+			_deletePage.apply( this, arguments );
 			return this;
 		};
 		API.setDisplayMode = function(zoom, layout, pmode) {

--- a/jspdf.js
+++ b/jspdf.js
@@ -181,7 +181,7 @@ var jsPDF = (function(global) {
 			page = 0,
 			currentPage,
 			pages = [],
-			pagedim = {},
+			pagedim = [],
 			content = [],
 			lineCapID = 0,
 			lineJoinID = 0,


### PR DESCRIPTION
This is somewhat of an emergency patch because the current implementation of the delete page function does not handle the cases where n = 0 or n = page.

The current algorithm shifts all the pages down one index from n to page, but if n equals page, the loop is never run and the page property is still decremented. If n equals zero, then all pages will still be shifted down, which screws up the indexing. The use of splice ensures that the requested page is properly removed from the collections.

HOWEVER, pagedim is defined as an object for some reason. I have looked at its usage patterns and I can find no reason for this decision. It is only used with numeric indices, so I propose to change it to an array. 

If it is kept as an object, then the page deletion cases I mentioned above will have to be handled manually for pagedim. If we change it to an array, we can just call splice on it. Given how pagedim is only ever used with numeric indices, this should not be a breaking change.

Thoughts?