### PR TITLE
Fix right alignment in table cells

### DIFF
--- a/jspdf.plugin.cell.js
+++ b/jspdf.plugin.cell.js
@@ -124,12 +124,13 @@
                 this.rect(x, y, w, h);
             }
             if (align === 'right') {
-                if (txt instanceof Array) {
-                    for(var i = 0; i<txt.length; i++) {
-                        var currentLine = txt[i];
-                        var textSize = this.getStringUnitWidth(currentLine) * this.internal.getFontSize();
-                        this.text(currentLine, x + w - textSize - padding, y + this.internal.getLineHeight()*(i+1));
-                    }
+                if (!(txt instanceof Array)) {
+                    txt = [txt];
+                }
+                for (var i = 0; i < txt.length; i++) {
+                    var currentLine = txt[i];
+                    var textSize = this.getStringUnitWidth(currentLine) * this.internal.getFontSize();
+                    this.text(currentLine, x + w - textSize - padding, y + this.internal.getLineHeight()*(i+1));
                 }
             } else {
                 this.text(txt, x + padding, y + this.internal.getLineHeight());


### PR DESCRIPTION
Currently, if txt is passed in as a String, and the alignment option "right" is passed into jsPDF.cell, the cell in the PDF becomes blank with no text.

This is because an Array of text is expected in the right align block. This change simply inserts the text into an Array, if it's not an Array already.