### PR TITLE
Let's publish to npm

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1936,6 +1936,8 @@ var jsPDF = (function(global) {
 		define('jsPDF', function() {
 			return jsPDF;
 		});
+	} else if (typeof module !== 'undefined' && module.exports) {
+		module.exports = jsPDF;
 	} else {
 		global.jsPDF = jsPDF;
 	}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "jspdf",
   "version": "1.0.272",
+  "homepage": "https://github.com/mrrio/jspdf",
   "description": "PDF Document creation from JavaScript",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "main": "dist/jspdf.min.js",
+  "files": [
+    "dist/jspdf.min.js",
+    "README.md"
+  ],
+  "keywords": [
+    "pdf"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #183.

Filled in the remaining package.json fields to allow this package to be published to npm, and added CommonJS support so people can use this package with Browserify. You'll need to re-generate the  `dist` directory since I can't seem to run the build script on my machine.

Please note that npm != Node.js, so I recommend publishing this package to npm as soon as possible. We can work on adding Node.js support at a later date.