### PR TITLE
Get y coordinate from generated block from html, clear y coordinate after page break

### DIFF
--- a/plugins/cell.js
+++ b/plugins/cell.js
@@ -233,6 +233,9 @@
             if(config.fontSize){
                 fontSize = config.fontSize;
             }
+            if (config.css['font-size']) {
+                fontSize = config.css['font-size'] * 16;
+            }
             if(config.margins){
                 margins = config.margins;
             }

--- a/plugins/cell.js
+++ b/plugins/cell.js
@@ -105,6 +105,7 @@
 
     jsPDFAPI.cell = function (x, y, w, h, txt, ln, align) {
         var curCell = getLastCellPosition();
+        var pgAdded = false;
 
         // If this is not the first cell, we must change its position
         if (curCell.ln !== undefined) {
@@ -117,13 +118,14 @@
                 var margins = this.margins || NO_MARGINS;
                 if ((curCell.y + curCell.h + h + margin) >= this.internal.pageSize.height - margins.bottom) {
                     this.cellAddPage();
+                    pgAdded = true;
                     if (this.printHeaders && this.tableHeaderRow) {
                         this.printHeaderRow(ln, true);
                     }
                 }
                 //We ignore the passed y: the lines may have diferent heights
                 y = (getLastCellPosition().y + getLastCellPosition().h);
-
+                if (pgAdded) y = margin + 10;
             }
         }
 
@@ -393,6 +395,7 @@
 
             tableHeaderCell = this.tableHeaderRow[i];
             if (new_page) {
+                this.margins.top = margin;
                 tableHeaderCell[1] = this.margins && this.margins.top || 0;
                 tempHeaderConf.push(tableHeaderCell);
             }

--- a/plugins/from_html.js
+++ b/plugins/from_html.js
@@ -452,7 +452,8 @@
 						renderer.pdf.table(renderer.x, renderer.y, table2json.rows, table2json.headers, {
 							autoSize : false,
 							printHeaders : true,
-							margins : renderer.pdf.margins_doc
+							margins: renderer.pdf.margins_doc,
+							css: GetCSS(cn)
 						});
 						renderer.y = renderer.pdf.lastCellPos.y + renderer.pdf.lastCellPos.h + 20;
 					} else if (cn.nodeName === "OL" || cn.nodeName === "UL") {

--- a/plugins/from_html.js
+++ b/plugins/from_html.js
@@ -503,6 +503,7 @@
 			}
 			i++;
 		}
+		elementHandlers.outY = renderer.y;
 
 		if (isBlock) {
 			return renderer.setBlockBoundary(cb);

--- a/plugins/from_html.js
+++ b/plugins/from_html.js
@@ -451,7 +451,7 @@
 						renderer.y += 10;
 						renderer.pdf.table(renderer.x, renderer.y, table2json.rows, table2json.headers, {
 							autoSize : false,
-							printHeaders : true,
+							printHeaders: elementHandlers.printHeaders,
 							margins: renderer.pdf.margins_doc,
 							css: GetCSS(cn)
 						});


### PR DESCRIPTION
These small changes help me to work with this library in easier way.
usage:

        var doc = new jsPDF('p', 'pt', 'a4');
        var marginsDocProps2 = {
            top: lastTop,
            bottom: 0,
            left: 70
        };
        var docProps2ElementHandlers = { printHeaders: true }
        doc.fromHTML($('#documentProps2').get(0),
            marginsDocProps2.left,
            marginsDocProps2.top,
            {
                'elementHandlers': docProps2ElementHandlers
            },
            marginsDocProps2
        );
        var lastTop = docProps2ElementHandlers.outY - 20;

lastTop is y position of the last generated block so I know where I can start generate another block.