### PR TITLE
Fix overriding font w/ default font

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -791,8 +791,8 @@ var jsPDF = (function(global) {
 			case 'serif':
 			case 'cursive':
 			case 'fantasy':
-				default:
 				fontName = 'times';
+			default:
 				break;
 			}
 


### PR DESCRIPTION
When setting a font using `setFont`, all other than the cases listed in the switch statement in `getFont` will be overruled by the default font. For example, it is only possible to set **helvetica** by setting **sans-serif**, **verdana** or **arial**. Setting **helvetica** directly will set **times** as the font. This minor PR fixes this issue, as the _try and catch_ and _if_ statements will resolve the default case.
