### PR TITLE
Support all text stroke options

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1192,17 +1192,21 @@ var jsPDF = (function(global) {
 
 			var strokeOption = '';
 			var pageContext = this.internal.getCurrentPageInfo().pageContext;
-			if (true === flags.stroke){
-				if (pageContext.lastTextWasStroke !== true){
-					strokeOption = '1 Tr\n';
-					pageContext.lastTextWasStroke = true;
+			var strokeVal = 0;
+
+			if('stroke' in flags) {
+				if(true === flags.stroke) {
+					strokeVal = 1;
+				} else if (typeof flags.stroke == 'number') {
+					strokeVal = flags.stroke;
+				} else {
+					strokeVal = 0;
 				}
 			}
-			else{
-				if (pageContext.lastTextWasStroke){
-					strokeOption = '0 Tr\n';
-				}
-				pageContext.lastTextWasStroke = false;
+
+			if(pageContext.lastStrokeVal !== strokeVal) {
+				strokeOption = strokeVal + ' Tr\n';
+				pageContext.lastStrokeVal = strokeVal;
 			}
 
 			if (typeof this._runningPageHeight === 'undefined'){


### PR DESCRIPTION
Support all _text rendering modes_ via the `stroke` parameter. ([Spec](http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_reference_1-7.pdf#page=402))
Examples:

```
doc.text(35, 25, "Octonyan loves jsPDF", {
    stroke: 0 // Fill text
});

doc.text(35, 25, "Octonyan loves jsPDF", {
    stroke: 1 // Stroke text
});

doc.text(35, 25, "Octonyan loves jsPDF", {
    stroke: 2 // Fill, then stroke text
});


doc.text(35, 25, "Octonyan loves jsPDF", {
    stroke: 3 // Neither fill nor stroke text (invisible). 
});
```
