### PR TITLE
Specify unminified version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.1.135",
   "homepage": "https://github.com/mrrio/jspdf",
   "description": "PDF Document creation from JavaScript",
-  "main": "dist/jspdf.min.js",
+  "main": "dist/jspdf.debug.js",
   "moduleType": [
     "amd",
     "globals"


### PR DESCRIPTION
According to the [spec](https://github.com/bower/bower.json-spec) the `main` key should specify the unminified source.