### PR TITLE
Fix build.sh under non-bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,18 +32,18 @@ adler2="adler32-tmp.js"
 cat ${adler1} \
 	| sed -e 's/this, function/jsPDF, function/' \
 	| sed -e 's/typeof define/0/' > $adler2
-libs=${libs/$adler1/$adler2}
+libs="$(echo $libs | sed 's#$adler1#$adler2#')"
 saveas1="libs/FileSaver.js/FileSaver.js"
 saveas2="FileSaver-tmp.js"
 cat ${saveas1} \
 	| sed -e 's/define !== null) && (define.amd != null/0/' > $saveas2
-libs=${libs/$saveas1/$saveas2}
+libs="$(echo $libs | sed 's#$saveas1#$saveas2#')"
 
 # Build dist files
 cat ${files} ${libs} \
 	| sed s/\${versionID}/${version}-git\ Built\ on\ ${build}/ \
 	| sed s/\${commitID}/${commit}/ \
-	| sed "s/\"1\.0\.0-trunk\"/\"${version}-debug ${build}:${whoami}\"/" >${output/min/debug}
+	| sed "s/\"1\.0\.0-trunk\"/\"${version}-debug ${build}:${whoami}\"/" > "$(echo $output | sed s/min/debug/)"
 uglifyjs ${options} -o ${output} ${files} ${libs}
 
 # Pretend license information to minimized file


### PR DESCRIPTION
build.sh starts with `#/bin/sh` (as it should), but uses some bashisms, which cause ugly failures in other shells such as dash.
Use POSIX-compliant sed invocations instead of bash string replacements.