### PR TITLE
Fix and avoid getFont fontname aliasing

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -777,23 +777,26 @@ var jsPDF = (function(global) {
 			if (fontName !== undefined){
 				fontName = fontName.toLowerCase();
 			}
-			switch(fontName){
-			case 'sans-serif':
-			case 'verdana':
-			case 'arial':
-				fontName = 'helvetica';
-				break;
-			case 'fixed':
-			case 'monospace':
-			case 'terminal':
-				fontName = 'courier';
-				break;
-			case 'serif':
-			case 'cursive':
-			case 'fantasy':
-				default:
-				fontName = 'times';
-				break;
+			if (! fontmap[fontName]) {
+				switch(fontName){
+				case 'sans-serif':
+				case 'verdana':
+				case 'arial':
+				case 'helvetica':
+					fontName = 'helvetica';
+					break;
+				case 'fixed':
+				case 'monospace':
+				case 'terminal':
+					fontName = 'courier';
+					break;
+				case 'serif':
+				case 'cursive':
+				case 'fantasy':
+					default:
+					fontName = 'times';
+					break;
+				}
 			}
 
 			try {


### PR DESCRIPTION
Currently, users got times when they asked for helvetica. Add helvetica to the list.
Additionally, only do the automatic rewriting if the font name cannot be found in the first place, to re-allow custom fonts.
