### PR TITLE
Check for array in a way that is safe cross-frame

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1211,7 +1211,7 @@ var jsPDF = (function(global) {
 
 			if (typeof text === 'string') {
 				text = ESC(text);
-			} else if (text instanceof Array) {
+			} else if (Object.prototype.toString.call(text) === '[object Array]') {
 				// we don't want to destroy  original text array, so cloning it
 				var sa = text.concat(), da = [], len = sa.length;
 				// we do array.join('text that must not be PDFescaped")


### PR DESCRIPTION
In a cross-frame environment, instanceof doesn't work, so text() fails to identify an array parameter and throws an error.

see:
http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/