### PR TITLE
Rename (formerly-)reserved keyword in html2canvas

### DIFF
--- a/libs/html2canvas/dist/html2canvas.js
+++ b/libs/html2canvas/dist/html2canvas.js
@@ -2938,12 +2938,12 @@ function decode64(base64) {
     return output;
 }
 
-function SVGNodeContainer(node, native) {
+function SVGNodeContainer(node, _native) {
     this.src = node;
     this.image = null;
     var self = this;
 
-    this.promise = native ? new Promise(function(resolve, reject) {
+    this.promise = _native ? new Promise(function(resolve, reject) {
         self.image = new Image();
         self.image.onload = resolve;
         self.image.onerror = reject;

--- a/libs/html2canvas/src/svgnodecontainer.js
+++ b/libs/html2canvas/src/svgnodecontainer.js
@@ -1,9 +1,9 @@
-function SVGNodeContainer(node, native) {
+function SVGNodeContainer(node, _native) {
     this.src = node;
     this.image = null;
     var self = this;
 
-    this.promise = native ? new Promise(function(resolve, reject) {
+    this.promise = _native ? new Promise(function(resolve, reject) {
         self.image = new Image();
         self.image.onload = resolve;
         self.image.onerror = reject;


### PR DESCRIPTION
Although "native" is a formerly-reserved keyword in JS, it can cause problems with some build tools, and browsers implementing ECMAScript <= 3. See https://github.com/niklasvh/html2canvas/issues/522.