### PR TITLE
Fix rounding errors for Acroform elements

### DIFF
--- a/plugins/acroform.js
+++ b/plugins/acroform.js
@@ -1581,32 +1581,32 @@ AcroForm.internal.calculateCoordinates = function (x, y, w, h) {
             x[2] = AcroForm.scale(x[2]);
             x[3] = AcroForm.scale(x[3]);
 
-            coordinates.lowerLeft_X = x[0] | 0;
-            coordinates.lowerLeft_Y = (mmtopx.call(this, this.internal.pageSize.height) - x[3] - x[1]) | 0;
-            coordinates.upperRight_X = x[0] + x[2] | 0;
-            coordinates.upperRight_Y = (mmtopx.call(this, this.internal.pageSize.height) - x[1]) | 0;
+            coordinates.lowerLeft_X = x[0] || 0;
+            coordinates.lowerLeft_Y = (mmtopx.call(this, this.internal.pageSize.height) - x[3] - x[1]) || 0;
+            coordinates.upperRight_X = x[0] + x[2] || 0;
+            coordinates.upperRight_Y = (mmtopx.call(this, this.internal.pageSize.height) - x[1]) || 0;
         } else {
             x = AcroForm.scale(x);
             y = AcroForm.scale(y);
             w = AcroForm.scale(w);
             h = AcroForm.scale(h);
-            coordinates.lowerLeft_X = x | 0;
-            coordinates.lowerLeft_Y = this.internal.pageSize.height - y | 0;
-            coordinates.upperRight_X = x + w | 0;
-            coordinates.upperRight_Y = this.internal.pageSize.height - y + h | 0;
+            coordinates.lowerLeft_X = x || 0;
+            coordinates.lowerLeft_Y = this.internal.pageSize.height - y || 0;
+            coordinates.upperRight_X = x + w || 0;
+            coordinates.upperRight_Y = this.internal.pageSize.height - y + h || 0;
         }
     } else {
         // old method, that is fallback, if we can't get the pageheight, the coordinate-system starts from lower left
         if (Array.isArray(x)) {
-            coordinates.lowerLeft_X = x[0] | 0;
-            coordinates.lowerLeft_Y = x[1] | 0;
-            coordinates.upperRight_X = x[0] + x[2] | 0;
-            coordinates.upperRight_Y = x[1] + x[3] | 0;
+            coordinates.lowerLeft_X = x[0] || 0;
+            coordinates.lowerLeft_Y = x[1] || 0;
+            coordinates.upperRight_X = x[0] + x[2] || 0;
+            coordinates.upperRight_Y = x[1] + x[3] || 0;
         } else {
-            coordinates.lowerLeft_X = x | 0;
-            coordinates.lowerLeft_Y = y | 0;
-            coordinates.upperRight_X = x + w | 0;
-            coordinates.upperRight_Y = y + h | 0;
+            coordinates.lowerLeft_X = x || 0;
+            coordinates.lowerLeft_Y = y || 0;
+            coordinates.upperRight_X = x + w || 0;
+            coordinates.upperRight_Y = y + h || 0;
         }
     }
 


### PR DESCRIPTION
**This pull request fixes the following issue:**

The current `calculateCoordinates` method rounds the coordinates down to the next integer. This leads to the problem, that form elements are not perfectly aligned with other elements.

Example code to reproduce:
```javascript
	var doc = new jsPDF();

	var radioGroup = new RadioButton();
	radioGroup.V = "/Test";
	radioGroup.Subtype = "Form";
	doc.addField(radioGroup);

	var radioButton1 = radioGroup.createOption("Test");
	radioButton1.Rect = [50, 50, 4, 4];
	radioButton1.AS = "/Test";

	doc.rect(50, 50, 4, 4);

	doc.save('Test.pdf');
```

Expected behaviour: The radio button is aligned with the rectangle
Actual behaviour: The radio button overlaps the rectangle at the right and at the bottom