### PR TITLE
TypeError: config.css is undefined

### DIFF
--- a/plugins/cell.js
+++ b/plugins/cell.js
@@ -235,7 +235,7 @@
             if(config.fontSize){
                 fontSize = config.fontSize;
             }
-            if (config.css['font-size']) {
+            if (config.css && typeof(config.css['font-size']) !== "undefined") {
                 fontSize = config.css['font-size'] * 16;
             }
             if(config.margins){


### PR DESCRIPTION
When invoking the jsPDF.table() method a "TypeError: config.css is undefined" is thrown when there is no font-size property on the css property of the config object that is passed. In this case execution halts.
Added check for config.css and config.css['font-size']. Used a negative typeof check for "undefined" instead of a positive one for "number" to respect loose typing.