### PR TITLE
Fix/form field appearance

### DIFF
--- a/plugins/acroform.js
+++ b/plugins/acroform.js
@@ -1248,7 +1248,7 @@ window["CheckBox"] = AcroForm.CheckBox;
 
 AcroForm.TextField = function () {
     AcroForm.Field.call(this);
-    //this.DA = AcroForm.createDefaultAppearanceStream();
+    this.DA = AcroForm.Appearance.createDefaultAppearanceStream();
     var _V;
     Object.defineProperty(this, 'V', {
         get: function () {

--- a/plugins/acroform.js
+++ b/plugins/acroform.js
@@ -1249,6 +1249,7 @@ window["CheckBox"] = AcroForm.CheckBox;
 AcroForm.TextField = function () {
     AcroForm.Field.call(this);
     this.DA = AcroForm.Appearance.createDefaultAppearanceStream();
+    this.F = 4;
     var _V;
     Object.defineProperty(this, 'V', {
         get: function () {


### PR DESCRIPTION
This pull request fixes two issues:

### Issue 1
When I enter a value in a textfield on OSX Preview, the entered value is not displayed.

How to reproduce:
1. Generate a PDF containing text fields, e.g. /examples/js/AcroForm.js
2. Open with OSX Preview
3. Edit the value of the text field
4. Click somewhere outside of the textbox

Expected behaviour: The edited value of the text field is visible
Actual behaviour: The text field is blank

This issue is fixed with the line `this.DA = AcroForm.Appearance.createDefaultAppearanceStream();` (actually, almost the same code has been commented out before. If there are good reasons for that, let me know)

### Issue 2
When I print a filled form, the values of text fields are not printed

How to reproduce:
1. Generate a PDF containing text fields, e.g. /examples/js/AcroForm.js
2. Open it (e.g. with Adobe Reader)
3. Edit the value of the text field
4. Print the PDF

Expected behaviour: The edited value of the text field is visible in the printed document
Actual behaviour: The text field is blank

This issue is fixed with the line `this.F = 4;`
For additional information on the print annotation flag see http://partners.adobe.com/public/developer/en/pdf/PDFReference.pdf, page 493.