### PR TITLE
Acroforms: Scale the content to the text field size

### DIFF
--- a/plugins/acroform.js
+++ b/plugins/acroform.js
@@ -677,9 +677,9 @@ Q\n";
      */
     createDefaultAppearanceStream: function (formObject) {
         var stream = "";
-        // Set Helvetica to Standard Font (12px)
+        // Set Helvetica to Standard Font (size: auto)
         // Color: Black
-        stream += "/Helv 12 Tf 0 g";
+        stream += "/Helv 0 Tf 0 g";
         return stream;
     }
 };


### PR DESCRIPTION
This pull request fixes an issue introduced by #773 

When filling a text field with a lot of content, the content is cropped. This was not the case before #773. I fixed this issue by setting the font size in the default appearance stream to auto.

See also http://partners.adobe.com/public/developer/en/pdf/PDFReference.pdf p. 535:
> A zero value for _size_ means that the font is to be _auto-sized_: its size is computed as a function of the height of the annotation rectangle.