### PR TITLE
Update fromHtml plugin to add compatibility with IE11

### DIFF
--- a/plugins/from_html.js
+++ b/plugins/from_html.js
@@ -495,7 +495,9 @@
 						}
 					}
 					// Only add the text if the text node is in the body element
-					if (cn.ownerDocument.body.contains(cn)){
+					//if (cn.ownerDocument.body.contains(cn)){
+					// Add compatibility with IE11
+					if(!!(cn.ownerDocument.body.compareDocumentPosition(cn) & 16)){
 						renderer.addText(value, fragmentCSS);						
 					}
 				} else if (typeof cn === "string") {


### PR DESCRIPTION
cn.ownerDocument.body.contains(cn) isn't working fine with IE11. Changing it to !!(cn.ownerDocument.body.compareDocumentPosition(cn) & 16) it do the job in all the browsers.
Fix for the Issue IE does not add text #610.
https://github.com/MrRio/jsPDF/issues/610