### PR TITLE
Ignore legacy code for closing path

### DIFF
--- a/HOTFIX_README.md
+++ b/HOTFIX_README.md
@@ -1,0 +1,29 @@
+#Hotfixes
+
+We sometimes bake-in solutions (A.K.A. hotfixes) to solve issues for specific use cases.
+
+When we deem a hotfix will not break existing code,
+ will make it default behaviour and mark the hotfix as _accepted_,
+ At that point the define can be removed.
+ 
+ To enable a hotfix, define the following member of your created PDF,
+where the pdf.hotfix field is the name of the hotfix.
+
+    var pdf new jsPDF(...);
+    pdf.hotfix.fill_close = true;
+  
+#Active Hotfixes
+
+##fill_close
+###Applies To
+context2d plugin
+
+### Affects
+Filling paths 
+
+### Description
+In certain cases, closing a fill would result in a path resolving to an incorrect point.
+The was most likely fixed when we refactored matrix logic.  Enabling this hotfix will ignore a most-likely unneeded workaround.
+ 
+#Accepted Hotfixes
+There a currently no accepted hotfixes.

--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -1143,10 +1143,15 @@
                         }
                     }
 
-                    // extra move bug causing close to resolve to wrong point
-                    var x = moves[i].start.x;
-                    var y = moves[i].start.y;
-                    this.internal.line2(c2d, x, y);
+                    if (this.pdf.hotfix && this.pdf.hotfix.fill_close) {
+                        // do nothing
+                    }
+                    else {
+                        // extra move bug causing close to resolve to wrong point
+                        var x = moves[i].start.x;
+                        var y = moves[i].start.y;
+                        this.internal.line2(c2d, x, y);
+                    }
 
                     this.pdf.internal.out('h');
                     this.pdf.internal.out('f');


### PR DESCRIPTION
This fixed one of SAP's reported issues. My other pull request also seems to have solved the problem thought. 

This PR addressed the 'hotfix' strategy we discussed last week.