### PR TITLE
Build fix for requirejs

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,15 +11,32 @@ bundle({
   debug: 'dist/jspdf.debug.js'
 })
 
-// Monkey patching adler32 and filesaver
-function monkeyPatch () {
+function monkeyPatch() {
   return {
     transform: (code, id) => {
       var file = id.split('/').pop()
+
       if (file === 'adler32cs.js') {
+        // Make library assign itself to the jsPDF instance instead
+        // of window to avoid polluting global scope  
         code = code.replace(/this, function/g, 'jsPDF, function')
+
+        // Remove call to require('buffer') since it is not used and
+        // might import a large arbitrary buffer library if a user is
+        // using a commonjs module bundler
         code = code.replace(/require\('buffer'\)/g, '{}')
       }
+
+      // Only one define call per module is allowed by requirejs so
+      // we have to remove calls that other libraries make
+      if (file === 'adler32cs.js') {
+        code = code.replace(/typeof define/g, '0')
+      } else if (file === 'FileSaver.js') {
+        code = code.replace(/define !== null\) && \(define.amd != null/g, '0')
+      } else if (file === 'html2canvas.js') {
+        code = code.replace(/&&\s+define.amd/g, '&& define.amd && false')
+      }
+
       return code
     }
   }
@@ -29,7 +46,7 @@ function monkeyPatch () {
 // This plugin makes sure specified local variables are preserved
 // and kept local. This plugin wouldn't be necessary if es2015
 // modules would be used.
-function rawjs (opts) {
+function rawjs(opts) {
   opts = opts || {}
   return {
     transform: (code, id) => {
@@ -54,6 +71,7 @@ function rawjs (opts) {
 function bundle (paths) {
   rollup.rollup({
     entry: './main.js',
+    context: 'window',
     plugins: [
       monkeyPatch(),
       rawjs({
@@ -72,7 +90,7 @@ function bundle (paths) {
   }).then((bundle) => {
     return bundle.generate({
       format: 'umd',
-      moduleName: 'jspdf'
+      moduleName: 'jsPDF'
     })
   }).then(output => {
     let code = output.code


### PR DESCRIPTION
My last efforts in adding complete module bundler support were incomplete as outlined in #869. This PR removes all define calls by the bundled libraries to enable full requirejs support.