### PR TITLE
[fromHtml] Add `class`-attribute support to elementHandlers

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -214,6 +214,7 @@ Followed by text node without any wrapping element. <span>And some long long tex
 This is more wrapping-less text.
 <p id="bypassme" style="font-size:120%">This paragraph will <strong style="font-size:120%">NOT</strong> be on resulting PDF because a special attached element handler will be looking for the ID - 'bypassme' - and should bypass rendering it.</p>
 <p style="font-size:120%;text-align:center">This is <strong style="font-size:120%">another</strong> paragraph.</p>
+<p>I want to hide this particular <span class="hide">word</span></p>
 <p style="text-align:justify">
   Integer dignissim urna tortor? Cum rhoncus, a lacus ultricies tincidunt, tristique lundium enim urna, magna? Sed, enim penatibus? Lacus pellentesque integer et pulvinar tortor? Dapibus in arcu arcu, vut dolor? Et! Placerat pulvinar cursus, urna ultrices arcu nunc, a ultrices dictumst elementum? Magnis rhoncus pellentesque, egestas enim purus, augue et nascetur sociis enim rhoncus. Adipiscing augue placerat tincidunt pulvinar ridiculus. Porta in sociis arcu et placerat augue sit enim nec hac massa, turpis ridiculus nunc phasellus pulvinar proin sit pulvinar, ultrices aliquet placerat amet? Lorem nunc porttitor etiam risus tempor placerat amet non hac, nunc sed odio augue? Turpis, magnis. Lorem pid, a porttitor tincidunt adipiscing sagittis pellentesque, mattis amet, duis proin, penatibus lectus lorem eros, nisi, tempor phasellus, elit.
 </p>
@@ -310,6 +311,10 @@ This is more wrapping-less text.
 , specialElementHandlers = {
     // element with id of "bypass" - jQuery style selector
     '#bypassme': function(element, renderer){
+        // true = "handled elsewhere, bypass text extraction"
+        return true
+    },
+    '.hide': function(element, renderer){
         // true = "handled elsewhere, bypass text extraction"
         return true
     }

--- a/examples/js/basic.js
+++ b/examples/js/basic.js
@@ -324,6 +324,10 @@ function demoFromHTML() {
 		'#bypassme': function(element, renderer){
 			// true = "handled elsewhere, bypass text extraction"
 			return true
+		},
+		'.hide': function(element, renderer){
+      		// true = "handled elsewhere, bypass text extraction"
+			return true
 		}
 	}
 

--- a/examples/js/from-html.js
+++ b/examples/js/from-html.js
@@ -4,6 +4,9 @@ var doc = new jsPDF();
 var specialElementHandlers = {
 	'#editor': function(element, renderer){
 		return true;
+	},
+	'.controls': function(element, renderer){
+		return true;
 	}
 };
 

--- a/plugins/from_html.js
+++ b/plugins/from_html.js
@@ -231,6 +231,7 @@
 		i,
 		isHandledElsewhere,
 		l,
+		classNames,
 		t;
 		isHandledElsewhere = false;
 		i = void 0;
@@ -261,7 +262,26 @@
 					i++;
 				}
 			}
+    }
+
+		// Try class names
+		classNames = element.className ? element.className.split(' ') : [];
+		for (i = 0; i < classNames.length; i++) {
+			handlers = elementHandlers['.' + classNames[i]];
+			if (!isHandledElsewhere && handlers) {
+				if (typeof handlers === "function") {
+					isHandledElsewhere = handlers(element, renderer);
+				} else {
+					i = 0;
+					l = handlers.length;
+					while (!isHandledElsewhere && i !== l) {
+						isHandledElsewhere = handlers[i](element, renderer);
+						i++;
+					}
+				}
+			}
 		}
+
 		return isHandledElsewhere;
 	};
 	tableToJson = function (table, renderer) {


### PR DESCRIPTION
In the fromHtml-plugin, it's now possible to pass class names (e.g. `.hide-print`) to the `elementHandlers`-option passed to `fromHTML()`.

Also adds usage examples to `index.html` and `examples/basic.html`.

#### Example
```
var specialElementHandlers = {
	'#editor': function(element, renderer){
		return true;
	},
	'.controls': function(element, renderer){
		// All elements with the `controls` class will not be shown in the PDF
		return true;
	}
};

doc.fromHTML($('body').get(0), 15, 15, {
	'width': 170, 
	'elementHandlers': specialElementHandlers
});
```