### PR TITLE
Feature scale text

### DIFF
--- a/HOTFIX_README.md
+++ b/HOTFIX_README.md
@@ -25,5 +25,18 @@ Filling paths
 In certain cases, closing a fill would result in a path resolving to an incorrect point.
 The was most likely fixed when we refactored matrix logic.  Enabling this hotfix will ignore a most-likely unneeded workaround.
  
+
+##scale_text
+
+###Applies To
+context2d plugin
+
+### Affects
+Drawing and Filling Text when a scale transformation is active.
+
+### Description
+jsPDF currently has no way to draw scaled text.  
+This hotfix scales the current font size by the x-axis scale factor.
+ 
 #Accepted Hotfixes
 There a currently no accepted hotfixes.

--- a/libs/canvg_context2d/canvg.js
+++ b/libs/canvg_context2d/canvg.js
@@ -3238,11 +3238,16 @@
 				}
 				//ss end
 
-				if (svg.opts['ignoreDimensions'] == true && e.style('width').hasValue() &&
-					e.style('height').hasValue()) {
-					cWidth = e.style('width').toPixels('x');
-					cHeight = e.style('height').toPixels('y');
-				}
+                //ss
+                if (svg.opts['ignoreDimensions'] == true && e.style('width').hasValue() && e.style('height').hasValue()) {
+                    try {
+                        cWidth = e.style('width').toPixels('x');
+                        cHeight = e.style('height').toPixels('y');
+                    } catch (e) {
+                        // This will always fail with jsPDF, as no viewport is set
+                    }
+                }
+                //ss end
 				svg.ViewPort.SetCurrent(cWidth, cHeight);
 
 				if (svg.opts['offsetX'] != null) e.attribute('x', true).value = svg.opts[

--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -299,7 +299,22 @@
                 this.path = origPath;
             }
 
-            this.pdf.text(text, x, this._getBaseline(y), null, degs);
+            var scale;
+            if (this.pdf.hotfix && this.pdf.hotfix.scale_text) {
+                scale = this._getTransform()[0];
+            }
+            else {
+                scale = 1;
+            }
+            if (scale === 1) {
+                this.pdf.text(text, x, this._getBaseline(y), null, degs);
+            }
+            else {
+                var oldSize = this.pdf.internal.getFontSize();
+                this.pdf.setFontSize(oldSize * scale);
+                this.pdf.text(text, x, this._getBaseline(y), null, degs);
+                this.pdf.setFontSize(oldSize);
+            }
 
             if (this.ctx._clip_path.length > 0) {
                 lines.push('Q');
@@ -337,9 +352,26 @@
                 this.path = origPath;
             }
 
-            this.pdf.text(text, x, this._getBaseline(y), {
+            var scale;
+            if (this.pdf.hotfix && this.pdf.hotfix.scale_text) {
+                scale = this._getTransform()[0];
+            }
+            else {
+                scale = 1;
+            }
+            if (scale === 1) {
+                this.pdf.text(text, x, this._getBaseline(y), {
                 stroke: true
             }, degs);
+            }
+            else {
+                var oldSize = this.pdf.internal.getFontSize();
+                this.pdf.setFontSize(oldSize * scale);
+                this.pdf.text(text, x, this._getBaseline(y), {
+                    stroke: true
+                }, degs);
+                this.pdf.setFontSize(oldSize);
+            }
 
             if (this.ctx._clip_path.length > 0) {
                 lines.push('Q');

--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -1251,6 +1251,8 @@
                 getWidth: function () {
                     var fontSize = pdf.internal.getFontSize();
                     var txtWidth = pdf.getStringUnitWidth(text) * fontSize / pdf.internal.scaleFactor;
+                    // Convert points to pixels
+                    txtWidth *= 1.3333;
                     return txtWidth;
                 },
 

--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -649,6 +649,7 @@
             x = this._wrapX(x);
             y = this._wrapY(y);
 
+            //TODO angles and radius need to be transformed
             var xpt = this._matrix_map_point(this.ctx._transform, [x, y]);
             x = xpt[0];
             y = xpt[1];
@@ -1491,30 +1492,51 @@
      */
 
     c2d.internal.createArc = function (radius, startAngle, endAngle, anticlockwise) {
-
         var EPSILON = 0.00001; // Roughly 1/1000th of a degree, see below
-
-        // normalize startAngle, endAngle to [-2PI, 2PI]
         var twoPI = Math.PI * 2;
+        var piOverTwo = Math.PI / 2.0;
+
+        // normalize startAngle, endAngle to [0, 2PI]
         var startAngleN = startAngle;
         if (startAngleN < twoPI || startAngleN > twoPI) {
             startAngleN = startAngleN % twoPI;
+        }
+        if (startAngleN < 0) {
+            startAngleN = twoPI + startAngleN;
         }
         var endAngleN = endAngle;
         if (endAngleN < twoPI || endAngleN > twoPI) {
             endAngleN = endAngleN % twoPI;
         }
+        if (endAngleN < 0) {
+            endAngleN = twoPI + endAngleN;
+        }
+
+        // Total arc angle is less than or equal to 2PI.
+        var totalAngle = Math.abs(endAngleN - startAngleN);
+        if (totalAngle < twoPI) {
+            if (totalAngle < twoPI) {
+                if (anticlockwise) {
+                    if (startAngle < endAngle) {
+                        totalAngle = twoPI - totalAngle;
+                    }
+                }
+                else {
+                    if (startAngle > endAngle) {
+                        totalAngle = twoPI - totalAngle;
+                    }
+                }
+            }
+        }
 
         // Compute the sequence of arc curves, up to PI/2 at a time.
-        // Total arc angle is less than 2PI.
         var curves = [];
-        var piOverTwo = Math.PI / 2.0;
-        // var sgn = (startAngle < endAngle) ? +1 : -1; // clockwise or counterclockwise
         var sgn = anticlockwise ? -1 : +1;
 
-        var a1 = startAngle;
-        for (var totalAngle = Math.min(twoPI, Math.abs(endAngleN - startAngleN)); totalAngle > EPSILON;) {
-            var a2 = a1 + sgn * Math.min(totalAngle, piOverTwo);
+        var a1 = startAngleN;
+        for (; totalAngle > EPSILON;) {
+            var remain = sgn * Math.min(totalAngle, piOverTwo);
+            var a2 = a1 + remain;
             curves.push(this.createSmallArc(radius, a1, a2));
             totalAngle -= Math.abs(a2 - a1);
             a1 = a2;
@@ -1522,6 +1544,7 @@
 
         return curves;
     };
+
 
     c2d.internal.getCurrentPage = function () {
         return this.pdf.internal.pages[this.pdf.internal.getCurrentPageInfo().pageNumber];


### PR DESCRIPTION
Currently there is no way to draw scaled text in jsPDF.  As a hack, you can now turn on a hotfix and the font size will be scaled based on the c2d transformation matrix.  For example, you can use the scale factor to size from one page size to another.

```
pdf.hotfix = {scale_text: true};	 
ctx.scale(.8, .8);
```

<img width="653" alt="5-1 before" src="https://cloud.githubusercontent.com/assets/819940/22847139/2f5780d0-efb9-11e6-93ad-53162ff35940.png">
<img width="639" alt="5-2 before" src="https://cloud.githubusercontent.com/assets/819940/22847140/2f6cc706-efb9-11e6-86bf-e87214eab539.png">
<img width="567" alt="5-1 fixed" src="https://cloud.githubusercontent.com/assets/819940/22847145/35fc26a2-efb9-11e6-90ac-27c9527bc393.png">
<img width="576" alt="5-2 fixed" src="https://cloud.githubusercontent.com/assets/819940/22847146/36063a48-efb9-11e6-8f48-3155e31cfafe.png">
