### PR TITLE
Feature scale text

### DIFF
--- a/HOTFIX_README.md
+++ b/HOTFIX_README.md
@@ -25,5 +25,18 @@ Filling paths
 In certain cases, closing a fill would result in a path resolving to an incorrect point.
 The was most likely fixed when we refactored matrix logic.  Enabling this hotfix will ignore a most-likely unneeded workaround.
  
+
+##scale_text
+
+###Applies To
+context2d plugin
+
+### Affects
+Drawing and Filling Text when a scale transformation is active.
+
+### Description
+jsPDF currently has no way to draw scaled text.  
+This hotfix scales the current font size by the x-axis scale factor.
+ 
 #Accepted Hotfixes
 There a currently no accepted hotfixes.

--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -299,7 +299,22 @@
                 this.path = origPath;
             }
 
-            this.pdf.text(text, x, this._getBaseline(y), null, degs);
+            var scale;
+            if (this.pdf.hotfix && this.pdf.hotfix.scale_text) {
+                scale = this._getTransform()[0];
+            }
+            else {
+                scale = 1;
+            }
+            if (scale === 1) {
+                this.pdf.text(text, x, this._getBaseline(y), null, degs);
+            }
+            else {
+                var oldSize = this.pdf.internal.getFontSize();
+                this.pdf.setFontSize(oldSize * scale);
+                this.pdf.text(text, x, this._getBaseline(y), null, degs);
+                this.pdf.setFontSize(oldSize);
+            }
 
             if (this.ctx._clip_path.length > 0) {
                 lines.push('Q');
@@ -337,9 +352,26 @@
                 this.path = origPath;
             }
 
-            this.pdf.text(text, x, this._getBaseline(y), {
+            var scale;
+            if (this.pdf.hotfix && this.pdf.hotfix.scale_text) {
+                scale = this._getTransform()[0];
+            }
+            else {
+                scale = 1;
+            }
+            if (scale === 1) {
+                this.pdf.text(text, x, this._getBaseline(y), {
                 stroke: true
             }, degs);
+            }
+            else {
+                var oldSize = this.pdf.internal.getFontSize();
+                this.pdf.setFontSize(oldSize * scale);
+                this.pdf.text(text, x, this._getBaseline(y), {
+                    stroke: true
+                }, degs);
+                this.pdf.setFontSize(oldSize);
+            }
 
             if (this.ctx._clip_path.length > 0) {
                 lines.push('Q');

--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -1251,6 +1251,8 @@
                 getWidth: function () {
                     var fontSize = pdf.internal.getFontSize();
                     var txtWidth = pdf.getStringUnitWidth(text) * fontSize / pdf.internal.scaleFactor;
+                    // Convert points to pixels
+                    txtWidth *= 1.3333;
                     return txtWidth;
                 },
 


### PR DESCRIPTION
Currently there is no way to draw scaled text in jsPDF.  As a hack, you can now turn on a hotfix and the font size will be scaled based on the c2d transformation matrix.  For example, you can use the scale factor to size from one page size to another.

```
pdf.hotfix = {scale_text: true};	 
ctx.scale(.8, .8);
```

<img width="653" alt="5-1 before" src="https://cloud.githubusercontent.com/assets/819940/22847139/2f5780d0-efb9-11e6-93ad-53162ff35940.png">
<img width="639" alt="5-2 before" src="https://cloud.githubusercontent.com/assets/819940/22847140/2f6cc706-efb9-11e6-86bf-e87214eab539.png">
<img width="567" alt="5-1 fixed" src="https://cloud.githubusercontent.com/assets/819940/22847145/35fc26a2-efb9-11e6-90ac-27c9527bc393.png">
<img width="576" alt="5-2 fixed" src="https://cloud.githubusercontent.com/assets/819940/22847146/36063a48-efb9-11e6-8f48-3155e31cfafe.png">
