### PR TITLE
Check for empty array before rendering arc

### DIFF
--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -932,6 +932,11 @@
                         moves[moves.length - 1].deltas.push(delta);
                         break;
                     case 'arc':
+                        //TODO this was hack to avoid out-of-bounds issue
+                        // No move-to before drawing the arc
+                        if (moves.length == 0) {
+                            moves.push({start: {x: 0, y: 0}, deltas: [], abs: []});
+                        }
                         moves[moves.length - 1].arc = true;
                         moves[moves.length - 1].abs.push(pt);
                         break;
@@ -1130,7 +1135,8 @@
                         moves[moves.length - 1].deltas.push(delta);
                         break;
                     case 'arc':
-                        //TODO this was hack to avoid out of bounds issue
+                        //TODO this was hack to avoid out-of-bounds issue
+                        // No move-to before drawing the arc
                         if (moves.length == 0) {
                             moves.push({start: {x: 0, y: 0}, deltas: [], abs: []});
                         }


### PR DESCRIPTION
Filled arcs were fixed, but not stroked arcs.  This hotfix handles 2 newly reported issues that prevent drawing due to a Javascript error.  Not a regression.

<img width="691" alt="arc_stroke 2" src="https://cloud.githubusercontent.com/assets/819940/23029046/3b6b3b50-f437-11e6-9095-f7ac540cf9c4.png">

<img width="551" alt="arc_stroke 1" src="https://cloud.githubusercontent.com/assets/819940/23029049/3ec3b674-f437-11e6-96a8-4efd9dddc3f5.png">
