### PR TITLE
Fix regression in angle calculation

### DIFF
--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -1544,28 +1544,14 @@
         if (startAngleN < 0) {
             startAngleN = twoPI + startAngleN;
         }
-        var endAngleN = endAngle;
-        if (endAngleN < twoPI || endAngleN > twoPI) {
-            endAngleN = endAngleN % twoPI;
+       
+        while (startAngle > endAngle) {
+            startAngle = startAngle - twoPI;
         }
-        if (endAngleN < 0) {
-            endAngleN = twoPI + endAngleN;
-        }
-
-        // Total arc angle is less than or equal to 2PI.
-        var totalAngle = Math.abs(endAngleN - startAngleN);
+        var totalAngle = Math.abs(endAngle - startAngle);
         if (totalAngle < twoPI) {
-            if (totalAngle < twoPI) {
-                if (anticlockwise) {
-                    if (startAngle < endAngle) {
-                        totalAngle = twoPI - totalAngle;
-                    }
-                }
-                else {
-                    if (startAngle > endAngle) {
-                        totalAngle = twoPI - totalAngle;
-                    }
-                }
+            if (anticlockwise) {
+                totalAngle = twoPI - totalAngle;
             }
         }
 


### PR DESCRIPTION
This hotfix updates the code used to calculate angle sizes.  This was a regression.

Before
<img width="636" alt="screen shot 2017-02-16 at 11 18 52 am" src="https://cloud.githubusercontent.com/assets/819940/23029818/bcccf650-f439-11e6-8a61-0f9a4edd711d.png">

After
<img width="656" alt="screen shot 2017-02-16 at 10 50 15 am" src="https://cloud.githubusercontent.com/assets/819940/23029832/c6cafac6-f439-11e6-8ce9-5fd3b3a2a66a.png">

