### PR TITLE
Ignore small transform scale values

### DIFF
--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -306,7 +306,8 @@
             else {
                 scale = 1;
             }
-            if (scale === 1) {
+            // In some cases the transform was very small (5.715760606202283e-17).  Most likely a canvg rounding error.
+            if (scale < .01) {
                 this.pdf.text(text, x, this._getBaseline(y), null, degs);
             }
             else {


### PR DESCRIPTION
This hotfix resolves issues when scaling text when transform has a very small value.  It is not rounded it down, so we add a sanity check here.  Ideally we would add a threshold in the transform operations...

This is a regression that only appears scale_text hotfix is enabled.

<img width="723" alt="screen shot 2017-02-16 at 12 15 55 pm" src="https://cloud.githubusercontent.com/assets/819940/23032445/66ee6b0c-f442-11e6-9b16-a569cf8e7003.png">
<img width="822" alt="screen shot 2017-02-16 at 12 16 21 pm" src="https://cloud.githubusercontent.com/assets/819940/23032450/688b949e-f442-11e6-9fb3-243bd4853ca1.png">
