### PR TITLE
Hot fix scale rotated text

### DIFF
--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -300,8 +300,10 @@
             }
 
             var scale;
+            var scale;
             if (this.pdf.hotfix && this.pdf.hotfix.scale_text) {
-                scale = this._getTransform()[0];
+                // We only use X axis as scale hint 
+                scale = this._matrix_decompose(this._getTransform()).scale[0];
             }
             else {
                 scale = 1;
@@ -354,8 +356,10 @@
             }
 
             var scale;
+            var scale;
             if (this.pdf.hotfix && this.pdf.hotfix.scale_text) {
-                scale = this._getTransform()[0];
+                // We only use the X axis as scale hint 
+                scale = this._matrix_decompose(this._getTransform()).scale[0];
             }
             else {
                 scale = 1;


### PR DESCRIPTION
The transformation matrix needs to be decomposed when rotated to get the scale factor.
<img width="818" alt="screen shot 2017-03-15 at 12 17 11 pm" src="https://cloud.githubusercontent.com/assets/819940/23958795/92c92d2e-0979-11e7-8d7b-5c5af73a8fe8.png">
