### PR TITLE
Fix link positioning

### DIFF
--- a/plugins/annotations.js
+++ b/plugins/annotations.js
@@ -162,8 +162,7 @@
 					}
 				}
 
-				//var pageHeight = this.internal.pageSize.height * this.internal.scaleFactor;
-				var rect = "/Rect [" + f2(anno.x * k) + " " + f2((pageHeight - anno.y) * k) + " " + f2(anno.x + anno.w * k) + " " + f2(pageHeight - (anno.y + anno.h) * k) + "] ";
+				var rect = "/Rect [" + f2(anno.x * k) + " " + f2((pageHeight - anno.y) * k) + " " + f2((anno.x + anno.w) * k) + " " + f2((pageHeight - (anno.y + anno.h)) * k) + "] ";
 
 				var line = '';
 				if (anno.options.url) {
@@ -240,30 +239,13 @@
 	};
 
 	/**
-	 * valid options
-	 * <li> pageNumber or url [required]
-	 * <p>If pageNumber is specified, top and zoom may also be specified</p>
-	 */
-	jsPDFAPI.link = function(x,y,w,h,options) {
-		'use strict';
-		this.annotationPlugin.annotations[this.internal.getCurrentPageInfo().pageNumber].push({
-			x : x,
-			y : y,
-			w : w,
-			h : h,
-			options : options,
-			type : 'link'
-		});
-	};
-
-	/**
 	 * Currently only supports single line text.
 	 * Returns the width of the text/link
 	 */
 	jsPDFAPI.textWithLink = function(text,x,y,options) {
 		'use strict';
 		var width = this.getTextWidth(text);
-		var height = this.internal.getLineHeight();
+		var height = this.internal.getLineHeight() / this.internal.scaleFactor;
 		this.text(text, x, y);
 		//TODO We really need the text baseline height to do this correctly.
 		// Or ability to draw text on top, bottom, center, or baseline.


### PR DESCRIPTION
* scaleFactor (k) is now correctly applied when calculating link rectangle and textWithLink height
* Also removed redundant declaration of `jsPDFAPI.link`, which was declared twice

Closes #638
Related issues/PRs: #170, #390