### PR TITLE
Scale Factor Inverted - Fix

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1051,7 +1051,7 @@ var jsPDF = (function(global) {
         k = 72;
         break;
       case 'px':
-        k = 96 / 72;
+        k = 72 / 96;
         break;
       case 'pc':
         k = 12;


### PR DESCRIPTION
The scale factor for pixels was inverted.  This makes all items with the unit px be too large.  Scale factor should be inverted.