### PR TITLE
Hotfix : Correct px unit scaling factor

### DIFF
--- a/HOTFIX_README.md
+++ b/HOTFIX_README.md
@@ -13,12 +13,24 @@ where the pdf.hotfix field is the name of the hotfix.
     pdf.hotfix.fill_close = true;
   
 # Active Hotfixes
-There are currently no active hotfixes.
+## px_scaling
+
+### Applies To
+jsPDF Core
+
+### Description
+When supplying 'px' as the unit for the PDF, the internal scaling factor was being miscalculated making drawn components
+larger than they should be.  Enabling this hotfix will correct this scaling calculation and items will be drawn to the
+correct scale.
+
+### To Enable
+To enable this hotfix, supply a 'hotfixes' array to the options object in the jsPDF constructor function, and add the
+string 'px_scaling' to this array.
 
 #Accepted Hotfixes
 ## scale_text
 
-###Applies To
+### Applies To
 context2d plugin
 
 ### Affects

--- a/jspdf.js
+++ b/jspdf.js
@@ -165,8 +165,8 @@ var jsPDF = (function(global) {
    * @constructor
    * @private
    */
-  function jsPDF(orientation, unit, format, compressPdf, options) {
-    var options = options || {};
+  function jsPDF(orientation, unit, format, compressPdf) {
+    var options = {};
 
     if (typeof orientation === 'object') {
       options = orientation;

--- a/jspdf.js
+++ b/jspdf.js
@@ -165,8 +165,8 @@ var jsPDF = (function(global) {
    * @constructor
    * @private
    */
-  function jsPDF(orientation, unit, format, compressPdf) {
-    var options = {};
+  function jsPDF(orientation, unit, format, compressPdf, options) {
+    var options = options || {};
 
     if (typeof orientation === 'object') {
       options = orientation;
@@ -221,6 +221,7 @@ var jsPDF = (function(global) {
       },
       API = {},
       events = new PubSub(API),
+      hotfixes = options.hotfixes || [],
 
       /////////////////////
       // Private functions
@@ -1035,7 +1036,16 @@ var jsPDF = (function(global) {
               '" is not supported.');
         }
         // @TODO: Add different output options
-      });
+      }),
+      /**
+       * Used to see if a supplied hotfix was requested when the pdf instance was created.
+       * @param {String} hotfixName - The name of the hotfix to check.
+       * @returns {boolean}
+       */
+      hasHotfix = function(hotfixName){
+        return (Array.isArray(hotfixes) == true
+         && hotfixes.indexOf(hotfixName) > -1);
+      };
 
     switch (unit) {
       case 'pt':
@@ -1152,7 +1162,8 @@ var jsPDF = (function(global) {
       },
       'getPDFVersion': function() {
         return pdfVersion;
-      }
+      },
+      'hasHotfix': hasHotfix      //Expose the hasHotfix check so plugins can also check them.
     };
 
     /**

--- a/jspdf.js
+++ b/jspdf.js
@@ -1061,7 +1061,12 @@ var jsPDF = (function(global) {
         k = 72;
         break;
       case 'px':
-        k = 96 / 72;
+        if (hasHotfix('px_scaling') == true) {
+          k = 72 / 96;
+        }
+        else {
+          k = 96 / 72;
+        }
         break;
       case 'pc':
         k = 12;


### PR DESCRIPTION
When supplying 'px' as the unit for the PDF, the internal scaling factor was being miscalculated making drawn components larger than they should be.  Enabling this hotfix will correct this scaling calculation and items will be drawn to the correct scale.

Note:  This PR includes dependency function 'hasHotfix' as discussed here: https://github.com/MrRio/jsPDF/pull/1173