### PR TITLE
Update example to display text on-screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var doc = new jsPDF({
   format: [4, 2]
 })
 
-doc.text('Hello world!', 10, 10)
+doc.text('Hello world!', 1, 1)
 doc.save('two-by-four.pdf')
 ```
 


### PR DESCRIPTION
* Fix the readme's second example, which was putting text at an invalid coordinate

Closes #1220