### PR TITLE
Resolves issue #665 - Adds CMYK JPEG Support

### DIFF
--- a/plugins/addimage.js
+++ b/plugins/addimage.js
@@ -706,7 +706,10 @@
 
 		if(this.isString(data)) {
 			dims = getJpegSize(data);
-			return this.createImageInfo(data, dims[0], dims[1], dims[3] == 1 ? this.color_spaces.DEVICE_GRAY:colorSpace, bpc, filter, index, alias);
+			if(dims[3] == 1) colorSpace = this.color_spaces.DEVICE_GRAY;
+			else if(dims[3] == 4) colorSpace = this.color_spaces.DEVICE_CMYK;
+			
+			return this.createImageInfo(data, dims[0], dims[1], colorSpace, bpc, filter, index, alias);
 		}
 
 		if(this.isArrayBuffer(data))
@@ -719,7 +722,10 @@
 			// if we already have a stored binary string rep use that
 			data = dataAsBinaryString || this.arrayBufferToBinaryString(data);
 
-			return this.createImageInfo(data, dims.width, dims.height, dims.numcomponents == 1 ? this.color_spaces.DEVICE_GRAY:colorSpace, bpc, filter, index, alias);
+			if(dims.numcomponents == 1) colorSpace = this.color_spaces.DEVICE_GRAY;
+			else if(dims.numcomponents == 4) colorSpace = this.color_spaces.DEVICE_CMYK;
+			
+			return this.createImageInfo(data, dims.width, dims.height, colorSpace, bpc, filter, index, alias);
 		}
 
 		return null;


### PR DESCRIPTION
Currently addImage assumes all jpeg data is RGB.
It does check for grayscale and adjust for that, but it doesn't try to handle CMYK at all.

This fix checks to see how many components there are, if there are 4 it assumes that the image is CMYK.

Technically it could be some other color space such as YCCK. But, rather than try to be perfect, this is an improvement on the current RGB assumption, so that at least CMYK images will work.

It will not break anything for images that are RGB, it will add support for CMYK, and it will remain not working properly for other color spaces.