### PR TITLE
Fix in getTextDimensions(): Ue correct font.

### DIFF
--- a/plugins/cell.js
+++ b/plugins/cell.js
@@ -71,8 +71,8 @@
             text.style.fontWeight = fontStyle;
         }
 
-        text.style.fontFamily = fontName;
         text.style.fontSize = fontSize + 'pt';
+        text.style.fontFamily = fontName;
         try {
             text.textContent = txt;            
         } catch(e) {

--- a/plugins/cell.js
+++ b/plugins/cell.js
@@ -71,7 +71,7 @@
             text.style.fontWeight = fontStyle;
         }
 
-        text.style.fontName = fontName;
+        text.style.fontFamily = fontName;
         text.style.fontSize = fontSize + 'pt';
         try {
             text.textContent = txt;            


### PR DESCRIPTION
`getTextDimensions()` doesn't use the correct font when it comes to render the test-text in the HTML document.

Would fix issue https://github.com/MrRio/jsPDF/issues/296