### PR TITLE
Updated getBlob function to display content in Adobe Acrobat

### DIFF
--- a/dist/jspdf.debug.js
+++ b/dist/jspdf.debug.js
@@ -1147,7 +1147,7 @@ var jsPDF = function (global) {
     },
         getBlob = function getBlob() {
       return new Blob([getArrayBuffer()], {
-        type: "application/pdf"
+        type: "data:application/pdf;base64"
       });
     },
 


### PR DESCRIPTION
**Problem**
PDF files generated by the previous version 1.3.4 cannot display some content if opened by Adobe Acrobat, leaving blank instead. The original issue [Adobe Acrobat doesn't display all content in the PDF file generated by jsPDF #1316](https://github.com/MrRio/jsPDF/issues/1316) is described with code.

**Solution**
Replaced line `1150` of jspdf.debug.js, `type: "application/pdf"`, with` type: "data:application/pdf;base64"`.