### PR TITLE
Add Graphics State Stack Operator

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1549,6 +1549,16 @@ var jsPDF = (function(global) {
       // (see Section 4.4.3, “Clipping Path Operators”)
       out('n');
     };
+    
+    // The q operator pushes a copy of the entire graphics state onto the stack.
+    API.pushGraphicsState = function() {
+    	out('q');
+    };
+    
+    // The Q operator restores the entire graphics state to its former value by popping it from the stack.
+    API.restoreGraphicsState = function() {
+    	out('Q');
+    };
 
     /**
      * Adds series of curves (straight lines or cubic bezier curves) to canvas, starting at `x`, `y` coordinates.


### PR DESCRIPTION
Add Graphics State Stack Operator For Clipping

There is no way to enlarge the current clipping path or to set a new clipping path without reference to the current one. However, since the clipping path is part of the graphics state, its effect can be localized to specific graphics
objects by enclosing the modification of the clipping path and the painting of those objects
between a pair of q and Q operators (see Section 4.3.1, “Graphics State Stack”).
Execution of the Q operator causes the clipping path to revert to the value that was saved by the q operator, before the clipping path was modified.