### PR TITLE
NPM package should point to .min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.4",
   "homepage": "https://github.com/mrrio/jspdf",
   "description": "PDF Document creation from JavaScript",
-  "main": "dist/jspdf.debug.js",
+  "main": "dist/jspdf.min.js",
   "files": [
     "dist/jspdf.debug.js",
     "dist/jspdf.min.js",


### PR DESCRIPTION
The NPM package should point to the minified version instead of the debug one.

The way things are at the moment, can't use for example the [AutoTable plugin](https://github.com/simonbengtsson/jsPDF-AutoTable) because that package does a `require('jspdf')` (when bundling with Webpack for example) -- so the jspdf debug version is getting embeded (which prints out debug statements etc).

It is also a bad practice to make the NPM package point to a debug version instead of the production version.