### PR TITLE
Update addhtml to handle bigger content

### DIFF
--- a/libs/polyfill.js
+++ b/libs/polyfill.js
@@ -5,192 +5,247 @@
  */
 
 (function (global) {
-	var b64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+    var b64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
-	if (typeof global.btoa === 'undefined') {
-		global.btoa = function(data) {
-			//  discuss at: http://phpjs.org/functions/base64_encode/
-			// original by: Tyler Akins (http://rumkin.com)
-			// improved by: Bayron Guevara
-			// improved by: Thunder.m
-			// improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-			// improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-			// improved by: Rafal Kukawski (http://kukawski.pl)
-			// bugfixed by: Pellentesque Malesuada
-			//   example 1: base64_encode('Kevin van Zonneveld');
-			//   returns 1: 'S2V2aW4gdmFuIFpvbm5ldmVsZA=='
+    if (typeof global.btoa === 'undefined') {
+        global.btoa = function(data) {
+            //  discuss at: http://phpjs.org/functions/base64_encode/
+            // original by: Tyler Akins (http://rumkin.com)
+            // improved by: Bayron Guevara
+            // improved by: Thunder.m
+            // improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+            // improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+            // improved by: Rafal Kukawski (http://kukawski.pl)
+            // bugfixed by: Pellentesque Malesuada
+            //   example 1: base64_encode('Kevin van Zonneveld');
+            //   returns 1: 'S2V2aW4gdmFuIFpvbm5ldmVsZA=='
 
-			var o1,o2,o3,h1,h2,h3,h4,bits,i = 0,ac = 0,enc = '',tmp_arr = [];
+            var o1,o2,o3,h1,h2,h3,h4,bits,i = 0,ac = 0,enc = '',tmp_arr = [];
 
-			if (!data) {
-				return data;
-			}
+            if (!data) {
+                return data;
+            }
 
-			do { // pack three octets into four hexets
-				o1 = data.charCodeAt(i++);
-				o2 = data.charCodeAt(i++);
-				o3 = data.charCodeAt(i++);
+            do { // pack three octets into four hexets
+                o1 = data.charCodeAt(i++);
+                o2 = data.charCodeAt(i++);
+                o3 = data.charCodeAt(i++);
 
-				bits = o1 << 16 | o2 << 8 | o3;
+                bits = o1 << 16 | o2 << 8 | o3;
 
-				h1 = bits >> 18 & 0x3f;
-				h2 = bits >> 12 & 0x3f;
-				h3 = bits >> 6 & 0x3f;
-				h4 = bits & 0x3f;
+                h1 = bits >> 18 & 0x3f;
+                h2 = bits >> 12 & 0x3f;
+                h3 = bits >> 6 & 0x3f;
+                h4 = bits & 0x3f;
 
-				// use hexets to index into b64, and append result to encoded string
-				tmp_arr[ac++] = b64.charAt(h1) + b64.charAt(h2) + b64.charAt(h3) + b64.charAt(h4);
-			} while (i < data.length);
+                // use hexets to index into b64, and append result to encoded string
+                tmp_arr[ac++] = b64.charAt(h1) + b64.charAt(h2) + b64.charAt(h3) + b64.charAt(h4);
+            } while (i < data.length);
 
-			enc = tmp_arr.join('');
+            enc = tmp_arr.join('');
 
-			var r = data.length % 3;
+            var r = data.length % 3;
 
-			return (r ? enc.slice(0, r - 3) : enc) + '==='.slice(r || 3);
-		};
-	}
+            return (r ? enc.slice(0, r - 3) : enc) + '==='.slice(r || 3);
+        };
+    }
 
-	if (typeof global.atob === 'undefined') {
-		global.atob = function(data) {
-			//  discuss at: http://phpjs.org/functions/base64_decode/
-			// original by: Tyler Akins (http://rumkin.com)
-			// improved by: Thunder.m
-			// improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-			// improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-			//    input by: Aman Gupta
-			//    input by: Brett Zamir (http://brett-zamir.me)
-			// bugfixed by: Onno Marsman
-			// bugfixed by: Pellentesque Malesuada
-			// bugfixed by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-			//   example 1: base64_decode('S2V2aW4gdmFuIFpvbm5ldmVsZA==');
-			//   returns 1: 'Kevin van Zonneveld'
+    if (typeof global.atob === 'undefined') {
+        global.atob = function(data) {
+            //  discuss at: http://phpjs.org/functions/base64_decode/
+            // original by: Tyler Akins (http://rumkin.com)
+            // improved by: Thunder.m
+            // improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+            // improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+            //    input by: Aman Gupta
+            //    input by: Brett Zamir (http://brett-zamir.me)
+            // bugfixed by: Onno Marsman
+            // bugfixed by: Pellentesque Malesuada
+            // bugfixed by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+            //   example 1: base64_decode('S2V2aW4gdmFuIFpvbm5ldmVsZA==');
+            //   returns 1: 'Kevin van Zonneveld'
 
-			var o1,o2,o3,h1,h2,h3,h4,bits,i = 0,ac = 0,dec = '',tmp_arr = [];
+            var o1,o2,o3,h1,h2,h3,h4,bits,i = 0,ac = 0,dec = '',tmp_arr = [];
 
-			if (!data) {
-				return data;
-			}
+            if (!data) {
+                return data;
+            }
 
-			data += '';
+            data += '';
 
-			do { // unpack four hexets into three octets using index points in b64
-				h1 = b64.indexOf(data.charAt(i++));
-				h2 = b64.indexOf(data.charAt(i++));
-				h3 = b64.indexOf(data.charAt(i++));
-				h4 = b64.indexOf(data.charAt(i++));
+            do { // unpack four hexets into three octets using index points in b64
+                h1 = b64.indexOf(data.charAt(i++));
+                h2 = b64.indexOf(data.charAt(i++));
+                h3 = b64.indexOf(data.charAt(i++));
+                h4 = b64.indexOf(data.charAt(i++));
 
-				bits = h1 << 18 | h2 << 12 | h3 << 6 | h4;
+                bits = h1 << 18 | h2 << 12 | h3 << 6 | h4;
 
-				o1 = bits >> 16 & 0xff;
-				o2 = bits >> 8 & 0xff;
-				o3 = bits & 0xff;
+                o1 = bits >> 16 & 0xff;
+                o2 = bits >> 8 & 0xff;
+                o3 = bits & 0xff;
 
-				if (h3 == 64) {
-					tmp_arr[ac++] = String.fromCharCode(o1);
-				} else if (h4 == 64) {
-					tmp_arr[ac++] = String.fromCharCode(o1, o2);
-				} else {
-					tmp_arr[ac++] = String.fromCharCode(o1, o2, o3);
-				}
-			} while (i < data.length);
+                if (h3 == 64) {
+                    tmp_arr[ac++] = String.fromCharCode(o1);
+                } else if (h4 == 64) {
+                    tmp_arr[ac++] = String.fromCharCode(o1, o2);
+                } else {
+                    tmp_arr[ac++] = String.fromCharCode(o1, o2, o3);
+                }
+            } while (i < data.length);
 
-			dec = tmp_arr.join('');
+            dec = tmp_arr.join('');
 
-			return dec;
-		};
-	}
+            return dec;
+        };
+    }
 
-	if (!Array.prototype.map) {
-		Array.prototype.map = function(fun /*, thisArg */) {
-			if (this === void 0 || this === null || typeof fun !== "function")
-				throw new TypeError();
+    if (!Array.prototype.map) {
+        Array.prototype.map = function(fun /*, thisArg */) {
+            if (this === void 0 || this === null || typeof fun !== "function")
+                throw new TypeError();
 
-			var t = Object(this), len = t.length >>> 0, res = new Array(len);
-			var thisArg = arguments.length > 1 ? arguments[1] : void 0;
-			for (var i = 0; i < len; i++) {
-				// NOTE: Absolute correctness would demand Object.defineProperty
-				//       be used.  But this method is fairly new, and failure is
-				//       possible only if Object.prototype or Array.prototype
-				//       has a property |i| (very unlikely), so use a less-correct
-				//       but more portable alternative.
-				if (i in t)
-					res[i] = fun.call(thisArg, t[i], i, t);
-			}
+            var t = Object(this), len = t.length >>> 0, res = new Array(len);
+            var thisArg = arguments.length > 1 ? arguments[1] : void 0;
+            for (var i = 0; i < len; i++) {
+                // NOTE: Absolute correctness would demand Object.defineProperty
+                //       be used.  But this method is fairly new, and failure is
+                //       possible only if Object.prototype or Array.prototype
+                //       has a property |i| (very unlikely), so use a less-correct
+                //       but more portable alternative.
+                if (i in t)
+                    res[i] = fun.call(thisArg, t[i], i, t);
+            }
 
-			return res;
-		};
-	}
+            return res;
+        };
+    }
 
 
-	if(!Array.isArray) {
-		Array.isArray = function(arg) {
-			return Object.prototype.toString.call(arg) === '[object Array]';
-		};
-	}
+    if(!Array.isArray) {
+        Array.isArray = function(arg) {
+            return Object.prototype.toString.call(arg) === '[object Array]';
+        };
+    }
 
-	if (!Array.prototype.forEach) {
-		Array.prototype.forEach = function(fun, thisArg) {
-			"use strict";
+    if (!Array.prototype.forEach) {
+        Array.prototype.forEach = function(fun, thisArg) {
+            "use strict";
 
-			if (this === void 0 || this === null || typeof fun !== "function")
-				throw new TypeError();
+            if (this === void 0 || this === null || typeof fun !== "function")
+                throw new TypeError();
 
-			var t = Object(this), len = t.length >>> 0;
-			for (var i = 0; i < len; i++) {
-				if (i in t)
-					fun.call(thisArg, t[i], i, t);
-			}
-		};
-	}
+            var t = Object(this), len = t.length >>> 0;
+            for (var i = 0; i < len; i++) {
+                if (i in t)
+                    fun.call(thisArg, t[i], i, t);
+            }
+        };
+    }
+    
+    if (!Array.prototype.includes) {
+          Array.prototype.includes = function(searchElement /*, fromIndex*/) {
+            'use strict';
+            if (this == null) {
+              throw new TypeError('Array.prototype.includes called on null or undefined');
+            }
+            
+            var O = Object(this);
+            var len = parseInt(O.length, 10) || 0;
+            if (len === 0) {
+              return false;
+            }
+            var n = parseInt(arguments[1], 10) || 0;
+            var k;
+            if (n >= 0) {
+              k = n;
+            } else {
+              k = len + n;
+              if (k < 0) {k = 0;}
+            }
+            var currentElement;
+            while (k < len) {
+              currentElement = O[k];
+              if (searchElement === currentElement ||
+                 (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
+                return true;
+              }
+              k++;
+            }
+            return false;
+          };
+        }
 
-	if (!Object.keys) {
-		Object.keys = (function () {
-			'use strict';
+    if (!Object.keys) {
+        Object.keys = (function () {
+            'use strict';
 
-			var hasOwnProperty = Object.prototype.hasOwnProperty,
-				hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
-				dontEnums = ['toString','toLocaleString','valueOf','hasOwnProperty',
-					'isPrototypeOf','propertyIsEnumerable','constructor'],
-				dontEnumsLength = dontEnums.length;
+            var hasOwnProperty = Object.prototype.hasOwnProperty,
+                hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
+                dontEnums = ['toString','toLocaleString','valueOf','hasOwnProperty',
+                    'isPrototypeOf','propertyIsEnumerable','constructor'],
+                dontEnumsLength = dontEnums.length;
 
-			return function (obj) {
-				if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
-					throw new TypeError();
-				}
-				var result = [], prop, i;
+            return function (obj) {
+                if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
+                    throw new TypeError();
+                }
+                var result = [], prop, i;
 
-				for (prop in obj) {
-					if (hasOwnProperty.call(obj, prop)) {
-						result.push(prop);
-					}
-				}
+                for (prop in obj) {
+                    if (hasOwnProperty.call(obj, prop)) {
+                        result.push(prop);
+                    }
+                }
 
-				if (hasDontEnumBug) {
-					for (i = 0; i < dontEnumsLength; i++) {
-						if (hasOwnProperty.call(obj, dontEnums[i])) {
-							result.push(dontEnums[i]);
-						}
-					}
-				}
-				return result;
-			};
-		}());
-	}
+                if (hasDontEnumBug) {
+                    for (i = 0; i < dontEnumsLength; i++) {
+                        if (hasOwnProperty.call(obj, dontEnums[i])) {
+                            result.push(dontEnums[i]);
+                        }
+                    }
+                }
+                return result;
+            };
+        }());
+    }
+    
+    if (typeof Object.assign != 'function') {
+          Object.assign = function(target) {
+            'use strict';
+            if (target == null) {
+              throw new TypeError('Cannot convert undefined or null to object');
+            }
 
-	if (!String.prototype.trim) {
-		String.prototype.trim = function () {
-			return this.replace(/^\s+|\s+$/g, '');
-		};
-	}
-	if (!String.prototype.trimLeft) {
-		String.prototype.trimLeft = function() {
-			return this.replace(/^\s+/g, "");
-		};
-	}
-	if (!String.prototype.trimRight) {
-		String.prototype.trimRight = function() {
-			return this.replace(/\s+$/g, "");
-		};
-	}
+            target = Object(target);
+            for (var index = 1; index < arguments.length; index++) {
+              var source = arguments[index];
+              if (source != null) {
+                for (var key in source) {
+                  if (Object.prototype.hasOwnProperty.call(source, key)) {
+                    target[key] = source[key];
+                  }
+                }
+              }
+            }
+            return target;
+          };
+        }
+
+    if (!String.prototype.trim) {
+        String.prototype.trim = function () {
+            return this.replace(/^\s+|\s+$/g, '');
+        };
+    }
+    if (!String.prototype.trimLeft) {
+        String.prototype.trimLeft = function() {
+            return this.replace(/^\s+/g, "");
+        };
+    }
+    if (!String.prototype.trimRight) {
+        String.prototype.trimRight = function() {
+            return this.replace(/\s+$/g, "");
+        };
+    }
 
 })(typeof self !== "undefined" && self || typeof window !== "undefined" && window || this);

--- a/plugins/addhtml.js
+++ b/plugins/addhtml.js
@@ -7,171 +7,173 @@
  */
 
 (function (jsPDFAPI) {
-	'use strict';
+    'use strict';
 
-	/**
-	 * Renders an HTML element to canvas object which added to the PDF
-	 *
-	 * This feature requires [html2canvas](https://github.com/niklasvh/html2canvas)
-	 * or [rasterizeHTML](https://github.com/cburgmer/rasterizeHTML.js)
-	 *
-	 * @returns {jsPDF}
-	 * @name addHTML
-	 * @param element {Mixed} HTML Element, or anything supported by html2canvas.
-	 * @param x {Number} starting X coordinate in jsPDF instance's declared units.
-	 * @param y {Number} starting Y coordinate in jsPDF instance's declared units.
-	 * @param options {Object} Additional options, check the code below.
-	 * @param callback {Function} to call when the rendering has finished.
-	 * NOTE: Every parameter is optional except 'element' and 'callback', in such
-	 *       case the image is positioned at 0x0 covering the whole PDF document
-	 *       size. Ie, to easily take screenshots of webpages saving them to PDF.
-	 * @deprecated This is being replace with a vector-supporting API. See
-	 * [this link](https://cdn.rawgit.com/MrRio/jsPDF/master/examples/html2pdf/showcase_supported_html.html)
-	 */
-	jsPDFAPI.addHTML = function (element, x, y, options, callback) {
-		'use strict';
+    /**
+     * Renders an HTML element to canvas object which added to the PDF
+     *
+     * This feature requires [html2canvas](https://github.com/niklasvh/html2canvas)
+     * or [rasterizeHTML](https://github.com/cburgmer/rasterizeHTML.js)
+     *
+     * @returns {jsPDF}
+     * @name addHTML
+     * @param element {Mixed} HTML Element, or anything supported by html2canvas.
+     * @param x {Number} starting X coordinate in jsPDF instance's declared units.
+     * @param y {Number} starting Y coordinate in jsPDF instance's declared units.
+     * @param options {Object} Additional options, check the code below.
+     * @param callback {Function} to call when the rendering has finished.
+     * NOTE: Every parameter is optional except 'element' and 'callback', in such
+     *       case the image is positioned at 0x0 covering the whole PDF document
+     *       size. Ie, to easily take screenshots of webpages saving them to PDF.
+     * @deprecated This is being replace with a vector-supporting API. See
+     * [this link](https://cdn.rawgit.com/MrRio/jsPDF/master/examples/html2pdf/showcase_supported_html.html)
+     */
+    jsPDFAPI.addHTML = function (element, x, y, options, callback) {
+        'use strict';
 
-		if(typeof html2canvas === 'undefined' && typeof rasterizeHTML === 'undefined')
-			throw new Error('You need either '
-				+'https://github.com/niklasvh/html2canvas'
-				+' or https://github.com/cburgmer/rasterizeHTML.js');
+        if(typeof html2canvas === 'undefined' && typeof rasterizeHTML === 'undefined')
+            throw new Error('You need either '
+                +'https://github.com/niklasvh/html2canvas'
+                +' or https://github.com/cburgmer/rasterizeHTML.js');
 
-		if(typeof x !== 'number') {
-			options = x;
-			callback = y;
-		}
+        if(typeof x !== 'number') {
+            options = x;
+            callback = y;
+        }
 
-		if(typeof options === 'function') {
-			callback = options;
-			options = null;
-		}
+        if(typeof options === 'function') {
+            callback = options;
+            options = null;
+        }
 
 
-		if(typeof callback !== 'function') {
-			callback = function () {};
-		}
+        if(typeof callback !== 'function') {
+            callback = function () {};
+        }
 
-		var I = this.internal, K = I.scaleFactor, W = I.pageSize.width, H = I.pageSize.height;
+        var I = this.internal, K = I.scaleFactor, W = I.pageSize.width, H = I.pageSize.height;
 
-		options = options || {};
-		options.onrendered = function(obj) {
-			x = parseInt(x) || 0;
-			y = parseInt(y) || 0;
-			var dim = options.dim || {};
-			var margin = Object.assign({top: 0, right: 0, bottom: 0, left: 0, useFor: 'content'}, options.margin);
-			var h = dim.h || 0;
-			var w = dim.w || Math.min(W,obj.width/K) - x;
+        options = options || {};
+        options.onrendered = function(obj) {
+            x = parseInt(x) || 0;
+            y = parseInt(y) || 0;
+            var dim = options.dim || {};
+            var margin = Object.assign({top: 0, right: 0, bottom: 0, left: 0, useFor: 'content'}, options.margin);
+            var h = dim.h || 0;
+            var w = dim.w || Math.min(W,obj.width/K) - x;
 
-			var format = options.format || 'JPEG';
-			var imageCompression = options.imageCompression || 'SLOW';
+            var format = options.format || 'JPEG';
+            var imageCompression = options.imageCompression || 'SLOW';
+            
+            var notFittingHeight = obj.height > (H - margin.top - margin.bottom);
 
-			if(obj.height > H && options.pagesplit) {
-				var cropArea = function (parmObj, parmX, parmY, parmWidth, parmHeight) {
-					var canvas = document.createElement('canvas');
-					canvas.height = parmHeight;
-					canvas.width = parmWidth;
-					var ctx = canvas.getContext('2d');
-					ctx.mozImageSmoothingEnabled = false;
-					ctx.webkitImageSmoothingEnabled = false;
-					ctx.msImageSmoothingEnabled = false;
-					ctx.imageSmoothingEnabled = false;
-				    ctx.fillStyle = options.backgroundColor || '#ffffff';
-				    ctx.fillRect(0,0,parmWidth,parmHeight);
-					ctx.drawImage(parmObj,parmX,parmY,parmWidth,parmHeight,0,0,parmWidth,parmHeight);
-					return canvas;
-				}
-				var crop = function() {
-					var cy = 0;
-					var cx = 0;
-					var position = {};
-					var isOverWide = false;
-					var width; 
-					var height; 
-					while(1) {
-						cx = 0;
-						position.top = (cy !== 0) ? margin.top: y;
-						position.left = (cy !== 0) ? margin.left: x;
-						isOverWide = (W - margin.left - margin.right)*K < obj.width;
-						if (margin.useFor === "content") {
-							if (cy === 0) {
-								width = Math.min((W - margin.left)*K,obj.width);
-								height = Math.min((H - margin.top)*K,obj.height - cy);
-							} else {
-								width = Math.min((W)*K,obj.width);
-								height = Math.min((H)*K,obj.height - cy);
-								position.top = 0;
-							}
-						} else {
-							width = Math.min((W - margin.left - margin.right)*K,obj.width);
-							height = Math.min((H - margin.bottom - margin.top)*K,obj.height - cy);
-						}
-						if (isOverWide) {
-							while (1) {
-								if (margin.useFor === "content") {
-									if (cx === 0) {
-										width = Math.min((W - margin.left)*K,obj.width);
-									} else {
-										width = Math.min((W)*K,obj.width - cx);
-										position.left = 0;
-									}
-								}
-								var canvas = cropArea(obj, cx, cy, width, height);
-								var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,imageCompression];
-								this.addImage.apply(this, args);
-								cx += width;
-								if (cx >= obj.width) {
-									break;
-								}
-								this.addPage();	
-							}
-						} else {
-							var canvas = cropArea(obj, 0, cy, width, height);
-							var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,imageCompression];
-							this.addImage.apply(this, args);
-						}
-						cy += height;
-						if(cy >= obj.height) {
-							break;
-						}
-						this.addPage();
-					}
-					callback(w,cy,null,args);
-				}.bind(this);
-				if(obj.nodeName === 'CANVAS') {
-					var img = new Image();
-					img.onload = crop;
-					img.src = obj.toDataURL("image/png");
-					obj = img;
-				} else {
-					crop();
-				}
-			} else {
-				var alias = Math.random().toString(35);
-				var args = [obj, x,y,w,h, format,alias,'SLOW'];
+            if(notFittingHeight && options.pagesplit) {
+                var cropArea = function (parmObj, parmX, parmY, parmWidth, parmHeight) {
+                    var canvas = document.createElement('canvas');
+                    canvas.height = parmHeight;
+                    canvas.width = parmWidth;
+                    var ctx = canvas.getContext('2d');
+                    ctx.mozImageSmoothingEnabled = false;
+                    ctx.webkitImageSmoothingEnabled = false;
+                    ctx.msImageSmoothingEnabled = false;
+                    ctx.imageSmoothingEnabled = false;
+                    ctx.fillStyle = options.backgroundColor || '#ffffff';
+                    ctx.fillRect(0,0,parmWidth,parmHeight);
+                    ctx.drawImage(parmObj,parmX,parmY,parmWidth,parmHeight,0,0,parmWidth,parmHeight);
+                    return canvas;
+                }
+                var crop = function() {
+                    var cy = 0;
+                    var cx = 0;
+                    var position = {};
+                    var isOverWide = false;
+                    var width; 
+                    var height; 
+                    while(1) {
+                        cx = 0;
+                        position.top = (cy !== 0) ? margin.top: y;
+                        position.left = (cy !== 0) ? margin.left: x;
+                        isOverWide = (W - margin.left - margin.right)*K < obj.width;
+                        if (margin.useFor === "content") {
+                            if (cy === 0) {
+                                width = Math.min((W - margin.left)*K,obj.width);
+                                height = Math.min((H - margin.top)*K,obj.height - cy);
+                            } else {
+                                width = Math.min((W)*K,obj.width);
+                                height = Math.min((H)*K,obj.height - cy);
+                                position.top = 0;
+                            }
+                        } else {
+                            width = Math.min((W - margin.left - margin.right)*K,obj.width);
+                            height = Math.min((H - margin.bottom - margin.top)*K,obj.height - cy);
+                        }
+                        if (isOverWide) {
+                            while (1) {
+                                if (margin.useFor === "content") {
+                                    if (cx === 0) {
+                                        width = Math.min((W - margin.left)*K,obj.width);
+                                    } else {
+                                        width = Math.min((W)*K,obj.width - cx);
+                                        position.left = 0;
+                                    }
+                                }
+                                var canvas = cropArea(obj, cx, cy, width, height);
+                                var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,imageCompression];
+                                this.addImage.apply(this, args);
+                                cx += width;
+                                if (cx >= obj.width) {
+                                    break;
+                                }
+                                this.addPage();    
+                            }
+                        } else {
+                            var canvas = cropArea(obj, 0, cy, width, height);
+                            var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,imageCompression];
+                            this.addImage.apply(this, args);
+                        }
+                        cy += height;
+                        if(cy >= obj.height) {
+                            break;
+                        }
+                        this.addPage();
+                    }
+                    callback(w,cy,null,args);
+                }.bind(this);
+                if(obj.nodeName === 'CANVAS') {
+                    var img = new Image();
+                    img.onload = crop;
+                    img.src = obj.toDataURL("image/png");
+                    obj = img;
+                } else {
+                    crop();
+                }
+            } else {
+                var alias = Math.random().toString(35);
+                var args = [obj, x,y,w,h, format,alias,imageCompression];
 
-				this.addImage.apply(this, args);
+                this.addImage.apply(this, args);
 
-				callback(w,h,alias,args);
-			}
-		}.bind(this);
+                callback(w,h,alias,args);
+            }
+        }.bind(this);
 
-		if(typeof html2canvas !== 'undefined' && !options.rstz) {
-			return html2canvas(element, options);
-		}
+        if(typeof html2canvas !== 'undefined' && !options.rstz) {
+            return html2canvas(element, options);
+        }
 
-		if(typeof rasterizeHTML !== 'undefined') {
-			var meth = 'drawDocument';
-			if(typeof element === 'string') {
-				meth = /^http/.test(element) ? 'drawURL' : 'drawHTML';
-			}
-			options.width = options.width || (W*K);
-			return rasterizeHTML[meth](element, void 0, options).then(function(r) {
-				options.onrendered(r.image);
-			}, function(e) {
-				callback(null,e);
-			});
-		}
+        if(typeof rasterizeHTML !== 'undefined') {
+            var meth = 'drawDocument';
+            if(typeof element === 'string') {
+                meth = /^http/.test(element) ? 'drawURL' : 'drawHTML';
+            }
+            options.width = options.width || (W*K);
+            return rasterizeHTML[meth](element, void 0, options).then(function(r) {
+                options.onrendered(r.image);
+            }, function(e) {
+                callback(null,e);
+            });
+        }
 
-		return null;
-	};
+        return null;
+    };
 })(jsPDF.API);

--- a/plugins/addhtml.js
+++ b/plugins/addhtml.js
@@ -63,6 +63,7 @@
 			var w = dim.w || Math.min(W,obj.width/K) - x;
 
 			var format = options.format || 'JPEG';
+			var imageCompression = options.imageCompression || 'SLOW';
 
 			if(obj.height > H && options.pagesplit) {
 				var cropArea = function (parmObj, parmX, parmY, parmWidth, parmHeight) {
@@ -70,6 +71,10 @@
 					canvas.height = parmHeight;
 					canvas.width = parmWidth;
 					var ctx = canvas.getContext('2d');
+					ctx.mozImageSmoothingEnabled = false;
+					ctx.webkitImageSmoothingEnabled = false;
+					ctx.msImageSmoothingEnabled = false;
+					ctx.imageSmoothingEnabled = false;
 				    ctx.fillStyle = options.backgroundColor || '#ffffff';
 				    ctx.fillRect(0,0,parmWidth,parmHeight);
 					ctx.drawImage(parmObj,parmX,parmY,parmWidth,parmHeight,0,0,parmWidth,parmHeight);
@@ -104,14 +109,14 @@
 							while (1) {
 								if (margin.useFor === "content") {
 									if (cx === 0) {
-										width = Math.min((W)*K,obj.width);
+										width = Math.min((W - margin.left)*K,obj.width);
 									} else {
-										width = Math.min((W)*K,obj.width);
+										width = Math.min((W)*K,obj.width - cx);
 										position.left = 0;
 									}
 								}
 								var canvas = cropArea(obj, cx, cy, width, height);
-								var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,'SLOW'];
+								var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,imageCompression];
 								this.addImage.apply(this, args);
 								cx += width;
 								if (cx >= obj.width) {
@@ -121,7 +126,7 @@
 							}
 						} else {
 							var canvas = cropArea(obj, 0, cy, width, height);
-							var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,'SLOW'];
+							var args = [canvas, position.left,position.top,canvas.width/K,canvas.height/K, format,null,imageCompression];
 							this.addImage.apply(this, args);
 						}
 						cy += height;

--- a/plugins/addhtml.js
+++ b/plugins/addhtml.js
@@ -59,7 +59,7 @@
             y = parseInt(y) || 0;
             var dim = options.dim || {};
             var margin = Object.assign({top: 0, right: 0, bottom: 0, left: 0, useFor: 'content'}, options.margin);
-            var h = dim.h || 0;
+            var h = dim.h || Math.min(H,obj.height/K);
             var w = dim.w || Math.min(W,obj.width/K) - x;
 
             var format = options.format || 'JPEG';

--- a/plugins/standard_fonts_metrics.js
+++ b/plugins/standard_fonts_metrics.js
@@ -28,6 +28,134 @@ MIT license.
 ;(function(API) {
 'use strict'
 
+/*
+# reference (Python) versions of 'compress' and 'uncompress'
+# only 'uncompress' function is featured lower as JavaScript
+# if you want to unit test "roundtrip", just transcribe the reference
+# 'compress' function from Python into JavaScript
+
+def compress(data):
+
+	keys =   '0123456789abcdef'
+	values = 'klmnopqrstuvwxyz'
+	mapping = dict(zip(keys, values))
+	vals = []
+	for key in data.keys():
+		value = data[key]
+		try:
+			keystring = hex(key)[2:]
+			keystring = keystring[:-1] + mapping[keystring[-1:]]
+		except:
+			keystring = key.join(["'","'"])
+			#print('Keystring is %s' % keystring)
+
+		try:
+			if value < 0:
+				valuestring = hex(value)[3:]
+				numberprefix = '-'
+			else:
+				valuestring = hex(value)[2:]
+				numberprefix = ''
+			valuestring = numberprefix + valuestring[:-1] + mapping[valuestring[-1:]]
+		except:
+			if type(value) == dict:
+				valuestring = compress(value)
+			else:
+				raise Exception("Don't know what to do with value type %s" % type(value))
+
+		vals.append(keystring+valuestring)
+	
+	return '{' + ''.join(vals) + '}'
+
+def uncompress(data):
+
+	decoded = '0123456789abcdef'
+	encoded = 'klmnopqrstuvwxyz'
+	mapping = dict(zip(encoded, decoded))
+
+	sign = +1
+	stringmode = False
+	stringparts = []
+
+	output = {}
+
+	activeobject = output
+	parentchain = []
+
+	keyparts = ''
+	valueparts = ''
+
+	key = None
+
+	ending = set(encoded)
+
+	i = 1
+	l = len(data) - 1 # stripping starting, ending {}
+	while i != l: # stripping {}
+		# -, {, }, ' are special.
+
+		ch = data[i]
+		i += 1
+
+		if ch == "'":
+			if stringmode:
+				# end of string mode
+				stringmode = False
+				key = ''.join(stringparts)
+			else:
+				# start of string mode
+				stringmode = True
+				stringparts = []
+		elif stringmode == True:
+			#print("Adding %s to stringpart" % ch)
+			stringparts.append(ch)
+
+		elif ch == '{':
+			# start of object
+			parentchain.append( [activeobject, key] )
+			activeobject = {}
+			key = None
+			#DEBUG = True
+		elif ch == '}':
+			# end of object
+			parent, key = parentchain.pop()
+			parent[key] = activeobject
+			key = None
+			activeobject = parent
+			#DEBUG = False
+
+		elif ch == '-':
+			sign = -1
+		else:
+			# must be number
+			if key == None:
+				#debug("In Key. It is '%s', ch is '%s'" % (keyparts, ch))
+				if ch in ending:
+					#debug("End of key")
+					keyparts += mapping[ch]
+					key = int(keyparts, 16) * sign
+					sign = +1
+					keyparts = ''
+				else:
+					keyparts += ch
+			else:
+				#debug("In value. It is '%s', ch is '%s'" % (valueparts, ch))
+				if ch in ending:
+					#debug("End of value")
+					valueparts += mapping[ch]
+					activeobject[key] = int(valueparts, 16) * sign
+					sign = +1
+					key = None
+					valueparts = ''
+				else:
+					valueparts += ch
+
+			#debug(activeobject)
+
+	return output
+
+*/
+
 /**
 Uncompresses data compressed into custom, base16-like format. 
 @public
@@ -205,60 +333,40 @@ char codes to StandardEncoding character codes. The encoding table is to be used
 somewhere around "pdfEscape" call.
 */
 
-var addStandardFontMetricsFunction = function (args) {
-	var postScriptName = args.postScriptName;
-	var fontName = args.fontName;
-	var fontStyle = args.fontStyle;
-	var encoding = args.encoding;
-	var metadata = args.metadata;
-	var mutex = args.mutex || {};
-	var scope = mutex.scope;
-	
-	var metrics
-	, unicode_section
-	, encodingBlock;
+API.events.push([ 
+	'addFont'
+	,function(font) {
+		var metrics
+		, unicode_section
+		, encoding = 'Unicode'
+		, encodingBlock;
 
-	metrics = fontMetrics['Unicode'][postScriptName];
-	if (metrics) {
-		if (metadata.Unicode === undefined) {
-			metadata.Unicode = metadata.Unicode || {encoding: {}, kerning: {}, widths: []};
+		metrics = fontMetrics[encoding][font.PostScriptName];
+		if (metrics) {
+			if (font.metadata[encoding]) {
+				unicode_section = font.metadata[encoding];
+			} else {
+				unicode_section = font.metadata[encoding] = {};
+			}
+
+			unicode_section.widths = metrics.widths;
+			unicode_section.kerning = metrics.kerning;
 		}
-		unicode_section = metadata.Unicode;
 
-		unicode_section.widths = metrics.widths;
-		unicode_section.kerning = metrics.kerning;
-	}
+		encodingBlock = encodings[encoding][font.PostScriptName];
+		if (encodingBlock) {
+			if (font.metadata[encoding]) {
+				unicode_section = font.metadata[encoding];
+			} else {
+				unicode_section = font.metadata[encoding] = {};
+			}
 
-	encodingBlock = encodings['Unicode'][postScriptName];
-	if (encodingBlock) {
-		if (metadata.Unicode === undefined) {
-			metadata.Unicode = metadata.Unicode || {encoding: {}, kerning: {}, widths: []};
-		}
-		unicode_section = metadata.Unicode;
-
-		unicode_section.encoding = encodingBlock;
-		if (encodingBlock.codePages && encodingBlock.codePages.length) {
-			encoding = encodingBlock.codePages[0];
+			unicode_section.encoding = encodingBlock;
+			if (encodingBlock.codePages && encodingBlock.codePages.length) {
+				font.encoding = encodingBlock.codePages[0];
+			}
 		}
 	}
+]) // end of adding event handler
 
-	return {
-		postScriptName: postScriptName,
-		fontName: fontName,
-		fontStyle: fontStyle,
-		encoding: encoding,
-		metadata: metadata
-	};
-}
-	
-if (jsPDF.FunctionsPool === undefined) {
-	jsPDF.FunctionsPool = {};
-}
-if (jsPDF.FunctionsPool.addFont === undefined) {
-	jsPDF.FunctionsPool.addFont = [];
-}
-
-jsPDF.FunctionsPool.addFont.push(
-	addStandardFontMetricsFunction
-);
 })(jsPDF.API);

--- a/plugins/standard_fonts_metrics.js
+++ b/plugins/standard_fonts_metrics.js
@@ -28,134 +28,6 @@ MIT license.
 ;(function(API) {
 'use strict'
 
-/*
-# reference (Python) versions of 'compress' and 'uncompress'
-# only 'uncompress' function is featured lower as JavaScript
-# if you want to unit test "roundtrip", just transcribe the reference
-# 'compress' function from Python into JavaScript
-
-def compress(data):
-
-	keys =   '0123456789abcdef'
-	values = 'klmnopqrstuvwxyz'
-	mapping = dict(zip(keys, values))
-	vals = []
-	for key in data.keys():
-		value = data[key]
-		try:
-			keystring = hex(key)[2:]
-			keystring = keystring[:-1] + mapping[keystring[-1:]]
-		except:
-			keystring = key.join(["'","'"])
-			#print('Keystring is %s' % keystring)
-
-		try:
-			if value < 0:
-				valuestring = hex(value)[3:]
-				numberprefix = '-'
-			else:
-				valuestring = hex(value)[2:]
-				numberprefix = ''
-			valuestring = numberprefix + valuestring[:-1] + mapping[valuestring[-1:]]
-		except:
-			if type(value) == dict:
-				valuestring = compress(value)
-			else:
-				raise Exception("Don't know what to do with value type %s" % type(value))
-
-		vals.append(keystring+valuestring)
-	
-	return '{' + ''.join(vals) + '}'
-
-def uncompress(data):
-
-	decoded = '0123456789abcdef'
-	encoded = 'klmnopqrstuvwxyz'
-	mapping = dict(zip(encoded, decoded))
-
-	sign = +1
-	stringmode = False
-	stringparts = []
-
-	output = {}
-
-	activeobject = output
-	parentchain = []
-
-	keyparts = ''
-	valueparts = ''
-
-	key = None
-
-	ending = set(encoded)
-
-	i = 1
-	l = len(data) - 1 # stripping starting, ending {}
-	while i != l: # stripping {}
-		# -, {, }, ' are special.
-
-		ch = data[i]
-		i += 1
-
-		if ch == "'":
-			if stringmode:
-				# end of string mode
-				stringmode = False
-				key = ''.join(stringparts)
-			else:
-				# start of string mode
-				stringmode = True
-				stringparts = []
-		elif stringmode == True:
-			#print("Adding %s to stringpart" % ch)
-			stringparts.append(ch)
-
-		elif ch == '{':
-			# start of object
-			parentchain.append( [activeobject, key] )
-			activeobject = {}
-			key = None
-			#DEBUG = True
-		elif ch == '}':
-			# end of object
-			parent, key = parentchain.pop()
-			parent[key] = activeobject
-			key = None
-			activeobject = parent
-			#DEBUG = False
-
-		elif ch == '-':
-			sign = -1
-		else:
-			# must be number
-			if key == None:
-				#debug("In Key. It is '%s', ch is '%s'" % (keyparts, ch))
-				if ch in ending:
-					#debug("End of key")
-					keyparts += mapping[ch]
-					key = int(keyparts, 16) * sign
-					sign = +1
-					keyparts = ''
-				else:
-					keyparts += ch
-			else:
-				#debug("In value. It is '%s', ch is '%s'" % (valueparts, ch))
-				if ch in ending:
-					#debug("End of value")
-					valueparts += mapping[ch]
-					activeobject[key] = int(valueparts, 16) * sign
-					sign = +1
-					key = None
-					valueparts = ''
-				else:
-					valueparts += ch
-
-			#debug(activeobject)
-
-	return output
-
-*/
-
 /**
 Uncompresses data compressed into custom, base16-like format. 
 @public
@@ -333,40 +205,60 @@ char codes to StandardEncoding character codes. The encoding table is to be used
 somewhere around "pdfEscape" call.
 */
 
-API.events.push([ 
-	'addFont'
-	,function(font) {
-		var metrics
-		, unicode_section
-		, encoding = 'Unicode'
-		, encodingBlock;
+var addStandardFontMetricsFunction = function (args) {
+	var postScriptName = args.postScriptName;
+	var fontName = args.fontName;
+	var fontStyle = args.fontStyle;
+	var encoding = args.encoding;
+	var metadata = args.metadata;
+	var mutex = args.mutex || {};
+	var scope = mutex.scope;
+	
+	var metrics
+	, unicode_section
+	, encodingBlock;
 
-		metrics = fontMetrics[encoding][font.PostScriptName];
-		if (metrics) {
-			if (font.metadata[encoding]) {
-				unicode_section = font.metadata[encoding];
-			} else {
-				unicode_section = font.metadata[encoding] = {};
-			}
-
-			unicode_section.widths = metrics.widths;
-			unicode_section.kerning = metrics.kerning;
+	metrics = fontMetrics['Unicode'][postScriptName];
+	if (metrics) {
+		if (metadata.Unicode === undefined) {
+			metadata.Unicode = metadata.Unicode || {encoding: {}, kerning: {}, widths: []};
 		}
+		unicode_section = metadata.Unicode;
 
-		encodingBlock = encodings[encoding][font.PostScriptName];
-		if (encodingBlock) {
-			if (font.metadata[encoding]) {
-				unicode_section = font.metadata[encoding];
-			} else {
-				unicode_section = font.metadata[encoding] = {};
-			}
+		unicode_section.widths = metrics.widths;
+		unicode_section.kerning = metrics.kerning;
+	}
 
-			unicode_section.encoding = encodingBlock;
-			if (encodingBlock.codePages && encodingBlock.codePages.length) {
-				font.encoding = encodingBlock.codePages[0];
-			}
+	encodingBlock = encodings['Unicode'][postScriptName];
+	if (encodingBlock) {
+		if (metadata.Unicode === undefined) {
+			metadata.Unicode = metadata.Unicode || {encoding: {}, kerning: {}, widths: []};
+		}
+		unicode_section = metadata.Unicode;
+
+		unicode_section.encoding = encodingBlock;
+		if (encodingBlock.codePages && encodingBlock.codePages.length) {
+			encoding = encodingBlock.codePages[0];
 		}
 	}
-]) // end of adding event handler
 
+	return {
+		postScriptName: postScriptName,
+		fontName: fontName,
+		fontStyle: fontStyle,
+		encoding: encoding,
+		metadata: metadata
+	};
+}
+	
+if (jsPDF.FunctionsPool === undefined) {
+	jsPDF.FunctionsPool = {};
+}
+if (jsPDF.FunctionsPool.addFont === undefined) {
+	jsPDF.FunctionsPool.addFont = [];
+}
+
+jsPDF.FunctionsPool.addFont.push(
+	addStandardFontMetricsFunction
+);
 })(jsPDF.API);


### PR DESCRIPTION
Example:

```
const doc = jsPDF()
    doc.addHTML(document.getElementById('toHTML'), 10, 10, {pagesplit: true, margin: {top: 10, right: 10, bottom: 10, left: 10, useFor: 'page'}}, function () {doc.save("test.pdf")})
```
![image](https://user-images.githubusercontent.com/5059100/30658304-88ad1ad4-9e3a-11e7-854a-682329d165b0.png)

 ```
const doc = jsPDF()
    doc.addHTML(document.getElementById('toHTML'), 10, 10, {pagesplit: true, margin: {top: 10, right: 10, bottom: 10, left: 10, useFor: 'content'}}, function () {doc.save("test.pdf")})
```

![image](https://user-images.githubusercontent.com/5059100/30658361-bea14eee-9e3a-11e7-9e00-d0bdf94c002e.png)


