### PR TITLE
context2d - Fix hollow paths being drawn as filled

### DIFF
--- a/plugins/context2d.js
+++ b/plugins/context2d.js
@@ -1125,7 +1125,9 @@
 
                 if (moves[i].close) {
                     this.pdf.internal.out('h');
-                    this.pdf.internal.out('f');
+                    if (style) { // only fill at final path move
+                        this.pdf.internal.out(style);
+                    }
                 }
                 else if (moves[i].arc) {
                     if (moves[i].start) {


### PR DESCRIPTION
The groundwork was already there in the context2d plugin to not set the fill until the final path instruction (rather than at path close), but just wasn't being used.

See example at https://jsfiddle.net/j8a5nzby/1/.
