### PR TITLE
Fix for #905 #1163 #1317

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/MrRio/jsPDF.git"
   },
   "dependencies": {
-    "adler32cs": "0.0.1",
+    "adler32cs": "git://github.com/dusanstanojeviccs/adler32cs.js",
     "cf-blob.js": "0.0.1",
     "file-saver": "1.3.3"
   },


### PR DESCRIPTION
Looks like adler32cs is no longer maintained, made package.json point to my fork of adler32cs that contains the loader.js fix.

The issue that was happening with loader.js is that adler32cs did not pass the id and the dependency array.

Fix: Added the id  'adler32cs' and an empty dependency array.

Test: Ran the build script and included the newly generated file into a production level product using loader.js (Ember cli app)

Result: No exception got thrown