### PR TITLE
Update outline.js to account for PDFs in inches or mm

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,6 +24,7 @@ module.exports = (config) => {
       'plugins/addhtml.js',
       'plugins/addimage.js',
       'plugins/viewerpreferences.js',
+      'plugins/outline.js',
 
       'tests/utils/compare.js',
       {

--- a/plugins/outline.js
+++ b/plugins/outline.js
@@ -187,7 +187,7 @@
 								// Explicit Destination
 								//WARNING this assumes page ids are 3,5,7, etc.
 								var info = pdf.internal.getPageInfo(item.options.pageNumber)
-								this.line('/Dest ' + '[' + info.objId + ' 0 R /XYZ 0 ' + this.ctx.pdf.internal.pageSize.height + ' 0]');
+								this.line('/Dest ' + '[' + info.objId + ' 0 R /XYZ 0 ' + this.ctx.pdf.internal.pageSize.height*this.ctx.pdf.internal.scaleFactor + ' 0]');
 								// this line does not work on all clients (pageNumber instead of page ref)
 								//this.line('/Dest ' + '[' + (item.options.pageNumber - 1) + ' /XYZ 0 ' + this.ctx.pdf.internal.pageSize.height + ' 0]');
 

--- a/saucelabs.karma.conf.js
+++ b/saucelabs.karma.conf.js
@@ -61,6 +61,7 @@ module.exports = (config) => {
       'plugins/autoprint.js',
       'plugins/addhtml.js',
       'plugins/viewerpreferences.js',
+      'plugins/outline.js',
       'tests/utils/compare.js',
       {
         pattern: 'tests/**/*.spec.js',

--- a/tests/outline/reference/bookmark-in.pdf
+++ b/tests/outline/reference/bookmark-in.pdf
@@ -1,0 +1,192 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<</Length 11>>
+stream
+14.40 w
+0 G
+endstream
+endobj
+5 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 6 0 R
+>>
+endobj
+6 0 obj
+<</Length 11>>
+stream
+14.40 w
+0 G
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R 5 0 R ]
+/Count 2
+>>
+endobj
+7 0 obj
+<</BaseFont/Helvetica/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+8 0 obj
+<</BaseFont/Helvetica-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+9 0 obj
+<</BaseFont/Helvetica-Oblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+10 0 obj
+<</BaseFont/Helvetica-BoldOblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+11 0 obj
+<</BaseFont/Courier/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+12 0 obj
+<</BaseFont/Courier-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+13 0 obj
+<</BaseFont/Courier-Oblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+14 0 obj
+<</BaseFont/Courier-BoldOblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+15 0 obj
+<</BaseFont/Times-Roman/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+16 0 obj
+<</BaseFont/Times-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+17 0 obj
+<</BaseFont/Times-Italic/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+18 0 obj
+<</BaseFont/Times-BoldItalic/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+19 0 obj
+<</BaseFont/ZapfDingbats/Type/Font
+/Encoding/StandardEncoding
+/Subtype/Type1>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 7 0 R
+/F2 8 0 R
+/F3 9 0 R
+/F4 10 0 R
+/F5 11 0 R
+/F6 12 0 R
+/F7 13 0 R
+/F8 14 0 R
+/F9 15 0 R
+/F10 16 0 R
+/F11 17 0 R
+/F12 18 0 R
+/F13 19 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+
+20 0 obj
+<<
+/Type /Outlines
+/First 21 0 R
+/Last 21 0 R
+/Count 1
+>> 
+endobj
+
+21 0 obj
+<<
+/Title (Page 1)
+/Parent 20 0 R
+/Dest [3 0 R /XYZ 0 841.89 0]
+>> 
+endobj
+
+22 0 obj
+<<
+/Producer (jsPDF 1.x-master)
+/CreationDate (D:20171205175141-05'00')
+>>
+endobj
+23 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Outlines 20 0 R
+>>
+endobj
+xref
+0 24
+0000000000 65535 f 
+0000000345 00000 n 
+0000001647 00000 n 
+0000000009 00000 n 
+0000000118 00000 n 
+0000000177 00000 n 
+0000000286 00000 n 
+0000000408 00000 n 
+0000000498 00000 n 
+0000000593 00000 n 
+0000000691 00000 n 
+0000000794 00000 n 
+0000000883 00000 n 
+0000000977 00000 n 
+0000001074 00000 n 
+0000001175 00000 n 
+0000001268 00000 n 
+0000001360 00000 n 
+0000001454 00000 n 
+0000001552 00000 n 
+0000001886 00000 n 
+0000001962 00000 n 
+0000002047 00000 n 
+0000002138 00000 n 
+trailer
+<<
+/Size 24
+/Root 23 0 R
+/Info 22 0 R
+>>
+startxref
+2259
+%%EOF

--- a/tests/outline/reference/bookmark-mm.pdf
+++ b/tests/outline/reference/bookmark-mm.pdf
@@ -1,0 +1,192 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<</Length 10>>
+stream
+0.57 w
+0 G
+endstream
+endobj
+5 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 6 0 R
+>>
+endobj
+6 0 obj
+<</Length 10>>
+stream
+0.57 w
+0 G
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R 5 0 R ]
+/Count 2
+>>
+endobj
+7 0 obj
+<</BaseFont/Helvetica/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+8 0 obj
+<</BaseFont/Helvetica-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+9 0 obj
+<</BaseFont/Helvetica-Oblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+10 0 obj
+<</BaseFont/Helvetica-BoldOblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+11 0 obj
+<</BaseFont/Courier/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+12 0 obj
+<</BaseFont/Courier-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+13 0 obj
+<</BaseFont/Courier-Oblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+14 0 obj
+<</BaseFont/Courier-BoldOblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+15 0 obj
+<</BaseFont/Times-Roman/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+16 0 obj
+<</BaseFont/Times-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+17 0 obj
+<</BaseFont/Times-Italic/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+18 0 obj
+<</BaseFont/Times-BoldItalic/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+19 0 obj
+<</BaseFont/ZapfDingbats/Type/Font
+/Encoding/StandardEncoding
+/Subtype/Type1>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 7 0 R
+/F2 8 0 R
+/F3 9 0 R
+/F4 10 0 R
+/F5 11 0 R
+/F6 12 0 R
+/F7 13 0 R
+/F8 14 0 R
+/F9 15 0 R
+/F10 16 0 R
+/F11 17 0 R
+/F12 18 0 R
+/F13 19 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+
+20 0 obj
+<<
+/Type /Outlines
+/First 21 0 R
+/Last 21 0 R
+/Count 1
+>> 
+endobj
+
+21 0 obj
+<<
+/Title (Page 1)
+/Parent 20 0 R
+/Dest [3 0 R /XYZ 0 841.89 0]
+>> 
+endobj
+
+22 0 obj
+<<
+/Producer (jsPDF 1.x-master)
+/CreationDate (D:20171205175141-05'00')
+>>
+endobj
+23 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Outlines 20 0 R
+>>
+endobj
+xref
+0 24
+0000000000 65535 f 
+0000000343 00000 n 
+0000001645 00000 n 
+0000000009 00000 n 
+0000000118 00000 n 
+0000000176 00000 n 
+0000000285 00000 n 
+0000000406 00000 n 
+0000000496 00000 n 
+0000000591 00000 n 
+0000000689 00000 n 
+0000000792 00000 n 
+0000000881 00000 n 
+0000000975 00000 n 
+0000001072 00000 n 
+0000001173 00000 n 
+0000001266 00000 n 
+0000001358 00000 n 
+0000001452 00000 n 
+0000001550 00000 n 
+0000001884 00000 n 
+0000001960 00000 n 
+0000002045 00000 n 
+0000002136 00000 n 
+trailer
+<<
+/Size 24
+/Root 23 0 R
+/Info 22 0 R
+>>
+startxref
+2257
+%%EOF

--- a/tests/outline/reference/bookmark-pt.pdf
+++ b/tests/outline/reference/bookmark-pt.pdf
@@ -1,0 +1,192 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<</Length 10>>
+stream
+0.20 w
+0 G
+endstream
+endobj
+5 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 6 0 R
+>>
+endobj
+6 0 obj
+<</Length 10>>
+stream
+0.20 w
+0 G
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R 5 0 R ]
+/Count 2
+>>
+endobj
+7 0 obj
+<</BaseFont/Helvetica/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+8 0 obj
+<</BaseFont/Helvetica-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+9 0 obj
+<</BaseFont/Helvetica-Oblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+10 0 obj
+<</BaseFont/Helvetica-BoldOblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+11 0 obj
+<</BaseFont/Courier/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+12 0 obj
+<</BaseFont/Courier-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+13 0 obj
+<</BaseFont/Courier-Oblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+14 0 obj
+<</BaseFont/Courier-BoldOblique/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+15 0 obj
+<</BaseFont/Times-Roman/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+16 0 obj
+<</BaseFont/Times-Bold/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+17 0 obj
+<</BaseFont/Times-Italic/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+18 0 obj
+<</BaseFont/Times-BoldItalic/Type/Font
+/Encoding/WinAnsiEncoding
+/Subtype/Type1>>
+endobj
+19 0 obj
+<</BaseFont/ZapfDingbats/Type/Font
+/Encoding/StandardEncoding
+/Subtype/Type1>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 7 0 R
+/F2 8 0 R
+/F3 9 0 R
+/F4 10 0 R
+/F5 11 0 R
+/F6 12 0 R
+/F7 13 0 R
+/F8 14 0 R
+/F9 15 0 R
+/F10 16 0 R
+/F11 17 0 R
+/F12 18 0 R
+/F13 19 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+
+20 0 obj
+<<
+/Type /Outlines
+/First 21 0 R
+/Last 21 0 R
+/Count 1
+>> 
+endobj
+
+21 0 obj
+<<
+/Title (Page 1)
+/Parent 20 0 R
+/Dest [3 0 R /XYZ 0 841.89 0]
+>> 
+endobj
+
+22 0 obj
+<<
+/Producer (jsPDF 1.x-master)
+/CreationDate (D:20171205175141-05'00')
+>>
+endobj
+23 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Outlines 20 0 R
+>>
+endobj
+xref
+0 24
+0000000000 65535 f 
+0000000343 00000 n 
+0000001645 00000 n 
+0000000009 00000 n 
+0000000118 00000 n 
+0000000176 00000 n 
+0000000285 00000 n 
+0000000406 00000 n 
+0000000496 00000 n 
+0000000591 00000 n 
+0000000689 00000 n 
+0000000792 00000 n 
+0000000881 00000 n 
+0000000975 00000 n 
+0000001072 00000 n 
+0000001173 00000 n 
+0000001266 00000 n 
+0000001358 00000 n 
+0000001452 00000 n 
+0000001550 00000 n 
+0000001884 00000 n 
+0000001960 00000 n 
+0000002045 00000 n 
+0000002136 00000 n 
+trailer
+<<
+/Size 24
+/Root 23 0 R
+/Info 22 0 R
+>>
+startxref
+2257
+%%EOF

--- a/tests/outline/standard.spec.js
+++ b/tests/outline/standard.spec.js
@@ -1,0 +1,38 @@
+'use strict'
+/* global describe, it, jsPDF, comparePdf */
+/**
+ * Standard spec tests
+ *
+ * These tests return the datauristring so that reference files can be generated.
+ * We compare the exact output.
+ */
+
+describe('Outline functions', () => {
+  it('should create a bookmark in a pdf generated with units in points', () => {
+    const doc = jsPDF({unit: 'pt'})
+    doc.outline.add(null, "Page 1", {pageNumber:1});
+    doc.addPage();
+
+    comparePdf(doc.output(), 'bookmark-pt.pdf', 'outline')
+  })
+
+  // @TODO: Document
+  it('should create a bookmark in a pdf generated with units in inches', () => {
+    const doc = jsPDF({unit: 'in'})
+    doc.outline.add(null, "Page 1", {pageNumber:1});
+    doc.addPage();
+
+    comparePdf(doc.output(), 'bookmark-in.pdf', 'outline')
+  })
+
+  // @TODO: Document
+  it('should create a bookmark in a pdf generated with units in mm', () => {
+    const doc = jsPDF({unit: 'mm'})
+    doc.outline.add(null, "Page 1", {pageNumber:1});
+    doc.addPage();
+
+    comparePdf(doc.output(), 'bookmark-mm.pdf', 'outline')
+  })
+
+  // @TODO: Document
+})

--- a/tests/outline/standard.spec.js
+++ b/tests/outline/standard.spec.js
@@ -9,27 +9,27 @@
 
 describe('Outline functions', () => {
   it('should create a bookmark in a pdf generated with units in points', () => {
-    const doc = jsPDF({unit: 'pt'})
-    doc.outline.add(null, "Page 1", {pageNumber:1});
-    doc.addPage();
+    var doc = new jsPDF({unit: 'pt'})
+    doc.outline.add(null, "Page 1", {pageNumber:1})
+    doc.addPage()
 
     comparePdf(doc.output(), 'bookmark-pt.pdf', 'outline')
   })
 
   // @TODO: Document
   it('should create a bookmark in a pdf generated with units in inches', () => {
-    const doc = jsPDF({unit: 'in'})
-    doc.outline.add(null, "Page 1", {pageNumber:1});
-    doc.addPage();
+    var doc = new jsPDF({unit: 'in'})
+    doc.outline.add(null, "Page 1", {pageNumber:1})
+    doc.addPage()
 
     comparePdf(doc.output(), 'bookmark-in.pdf', 'outline')
   })
 
   // @TODO: Document
   it('should create a bookmark in a pdf generated with units in mm', () => {
-    const doc = jsPDF({unit: 'mm'})
-    doc.outline.add(null, "Page 1", {pageNumber:1});
-    doc.addPage();
+    var doc = new jsPDF({unit: 'mm'})
+    doc.outline.add(null, "Page 1", {pageNumber:1})
+    doc.addPage()
 
     comparePdf(doc.output(), 'bookmark-mm.pdf', 'outline')
   })


### PR DESCRIPTION
pageSize.height needs to be multiplied by scaleFactor when creating XYZ destinations for pdf bookmarks, otherwise when using units other than 'pt' the bookmarks will point near the end of the page instead of the top of the page.