### PR TITLE
fix getters for backwards compatibility

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1304,6 +1304,15 @@ var jsPDF = (function (global) {
         },
         getHeight: function() {
           return pageHeight
+        },
+        // these are not used internally anymore
+        // but we leave them to not break backwards compatibility
+        // TODO: remove for 2.x
+        get width() {
+          return pageWidth
+        },
+        get height() {
+          return pageHeight
         }
       },
       'output': function (type, options) {


### PR DESCRIPTION
Because it "couldn't be done"... there is always a way :)

I don't know if simply the existence of these breaks IE8, or just calling them breaks it. If it's the latter, this change should be fine since nothing internally calls these methods. If it's the former, it is still possible to conditionally add these methods after detecting a valid browser, of which there are of course various methods.