### PR TITLE
Fix typo that prevented fallback from working

### DIFF
--- a/plugins/addimage.js
+++ b/plugins/addimage.js
@@ -97,7 +97,7 @@
 				}
 			}
 		}
-		if (result === 'UNKOWN' && fallbackFormat !== 'UNKNOWN' ) {
+		if (result === 'UNKNOWN' && fallbackFormat !== 'UNKNOWN' ) {
 			console.warn('FileType of Image not recognized. Processing image as "' + fallbackFormat + '".');
 			result = fallbackFormat;
 		}


### PR DESCRIPTION
There was a typo in the getImageFileTypeByImageData function that prevented the fallback from working. It was comparing to the string "UNKOWN" instead of "UNKNOWN".