### PR TITLE
Fix invalid type check

### DIFF
--- a/src/modules/acroform.js
+++ b/src/modules/acroform.js
@@ -2314,7 +2314,7 @@
           return _MaxLen;
         },
         set: function (value) {
-          if (typeof value === "integer") {
+          if (Number.isInteger(value) {
           _MaxLen = value;
           }
         }


### PR DESCRIPTION
`typeof value` will never be `"integer"`, but will instead be `"number"` for integers. This fixes the type check, and adds proper assurances that the number is an integer.

This alert was found on LGTM.com, and there are [a bunch of other alerts](https://lgtm.com/projects/g/MrRio/jsPDF/alerts) for this project that would probably be good to investigate.

`Number.isInteger` already has a polyfill added in this repo.

*(Full disclosure: I'm part of the team behind LGTM.com)*