### PR TITLE
Make server contributions easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm run build
+    command: npm start
+ports:
+  - port: 8000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ meteor add jspdf:core
 ## Contributing
 Build the library with `npm run build`. This will fetch all dependencies and then compile the `dist` files. To see the examples locally you can start a web server with `npm start` and go to `localhost:8000`.
 
+Alternatively, you can build jsPDF using these commands in a readily configured online workspace:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/MrRio/jsPDF)
+
 ## Credits
 - Big thanks to Daniel Dotsenko from [Willow Systems Corporation](https://github.com/willowsystems) for making huge contributions to the codebase.
 - Thanks to Ajaxian.com for [featuring us back in 2009](http://ajaxian.com/archives/dynamically-generic-pdfs-with-javascript).


### PR DESCRIPTION
This pull request allows to easily start building, running and contributing to jsPDF using Gitpod. Clicking on the link will start a small container with a shell in the cloud, and show a VS Code based IDE running in the browser. I configured it to automatically build jsPDF, then start the development server and show the running web application in a preview pane.

Here is what it looks like:
<img width="1792" alt="jspdf_in_gitpod" src="https://user-images.githubusercontent.com/3210701/51058418-019adb80-15e9-11e9-8baa-356e87b2c45f.png">

If you'd like to try it first, here's a test link:
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/32leaves/jsPDF)

@arasabbasi: as far as I know @bwl21 used jsPDF in Gitpod before - he also introduced me to jsPDF.