### PR TITLE
Fix bug with deletePage() not properly updating pagesContext()

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -1297,6 +1297,7 @@ var jsPDF = (function (global) {
     var _deletePage = function (n) {
       if (n > 0 && n <= page) {
         pages.splice(n, 1);
+        pagesContext.splice(n, 1);
         page--;
         if (currentPage > page) {
           currentPage = page;


### PR DESCRIPTION
deletePage() was not updating pagesContext[], causing havoc, particularly with documents where the pages were not all the same dimension or orientation. 