### PR TITLE
see #2011 - let getStringUnitWidths provide the sum of width of  each individual char

### DIFF
--- a/src/modules/split_text_to_size.js
+++ b/src/modules/split_text_to_size.js
@@ -112,18 +112,31 @@
   * @returns {number} result
   */
   var getStringUnitWidth = API.getStringUnitWidth = function (text, options) {
-    options = options || {};
 
-    var fontSize = options.fontSize || this.internal.getFontSize();
-    var font = options.font || this.internal.getFont();
-    var charSpace = options.charSpace || this.internal.getCharSpace();
-    var result = 0;
-    if (typeof font.metadata.widthOfString === "function") {
-      result = font.metadata.widthOfString(text, fontSize, charSpace) / fontSize;
-    } else {
-      result = getArraySum(getCharWidthsArray.apply(this, arguments));
+    self = this;
+    function _getStringUnitWidth_(text, options)
+    {
+      var options = options || {};
+
+      var fontSize = options.fontSize || self.internal.getFontSize();
+      var font = options.font || self.internal.getFont();
+      var charSpace = options.charSpace || self.internal.getCharSpace();
+      var result = 0;
+      if (typeof font.metadata.widthOfString === "function") {
+        result = font.metadata.widthOfString(text, fontSize, charSpace) / fontSize;
+      } else {
+        result = getArraySum(getCharWidthsArray.apply(self, arguments));
+      }
+      return result;
     }
-    return result;
+
+
+    var length = text.length;
+    var allresult = 0;
+      for (var i = 0; i < length; i++) {
+        allresult += _getStringUnitWidth_(text[i], options)
+      }
+    return allresult;
   };
 
   /**


### PR DESCRIPTION
This fixed the right adjustment problem in case of kerning.

to be honest I am not sure if this patch hides another problem. Maybe text() does not apply kerning.