### PR TITLE
Exclude definitely_typed and spec on LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+path_classifiers:
+  test:
+    - definitely_typed
+    - spec


### PR DESCRIPTION
As mentioned here: https://github.com/MrRio/jsPDF/pull/2123#issuecomment-481502030 @arasabbasi would like to exclude certain files in LGTM's analysis, this should do the trick.

Cheers,
Sam.