### PR TITLE
Update lgtm.yml file to exclude `types`

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,4 @@
 path_classifiers:
   test:
-    - definitely_typed
+    - types
     - spec


### PR DESCRIPTION
Looks like the files from `/definitely_typed` were moved to `/types` in 6c6ca0c, but the `lgtm.yml` file was not updated, which means the alert count has jumped back up again.

I've updated it here which should fix this.

Also, we've just launched [the LGTM GitHub App](https://lgtm.com/blog/announcing_github_apps_migration), which is a new way of using LGTM for automated code review on your projects. You'll be able to catch pull requests that introduce new alerts if you enable it. Let me know if you have any questions.

Cheers,
Sam.