### PR TITLE
image demo to use base64 image instead of url

### DIFF
--- a/examples/js/editor.js
+++ b/examples/js/editor.js
@@ -6,7 +6,7 @@
 var jsPDFEditor = function () {
 
 	var editor, demos = {
-		'images.js': 'Images',
+		'images_png.js': 'Images',
 		'font-faces.js': 'Font faces, text alignment and rotation',
 		'two-page.js': 'Two page Hello World',
 		'circles.js': 'Circles',


### PR DESCRIPTION
At the moment http://raw.githack.com/MrRio/jsPDF/master/ image demo is not working, see https://github.com/MrRio/jsPDF/issues/2478