### PR TITLE
containerCss backgroundColor: 'transparent'

### DIFF
--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -246,7 +246,7 @@
         right: 0,
         top: 0,
         margin: "auto",
-        backgroundColor: "white"
+        backgroundColor: this.opt.backgroundColor || "transparent"
       }; // Set the overlay to hidden (could be changed in the future to provide a print preview).
 
       var source = cloneNode(

--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -159,7 +159,8 @@
       x: 0,
       y: 0,
       html2canvas: {},
-      jsPDF: {}
+      jsPDF: {},
+      backgroundColor: "transparent"
     }
   };
 
@@ -246,7 +247,7 @@
         right: 0,
         top: 0,
         margin: "auto",
-        backgroundColor: this.opt.backgroundColor || "transparent"
+        backgroundColor: this.opt.backgroundColor
       }; // Set the overlay to hidden (could be changed in the future to provide a print preview).
 
       var source = cloneNode(


### PR DESCRIPTION
var containerCSS = {
...
backgroundColor: this.opt.backgroundColor || 'transparent'
};

white backgroundColor of containerCss overwrites the background of html2canvas. changed to transparent and also add an option to set backgroundColor from opt of jsPDF.