### PR TITLE
docs: Fix simple typo, wether -> whether

### DIFF
--- a/dist/jspdf.debug.js
+++ b/dist/jspdf.debug.js
@@ -19991,7 +19991,7 @@
       var framewidth = frame.width;
       var framestride = width - framewidth;
       var xleft = framewidth; // Number of subrect pixels left in scanline.
-      // Output indicies of the top left and bottom right corners of the subrect.
+      // Output indices of the top left and bottom right corners of the subrect.
 
       var opbeg = (frame.y * width + frame.x) * 4;
       var opend = ((frame.y + frame.height) * width + frame.x) * 4;
@@ -20057,7 +20057,7 @@
       var framewidth = frame.width;
       var framestride = width - framewidth;
       var xleft = framewidth; // Number of subrect pixels left in scanline.
-      // Output indicies of the top left and bottom right corners of the subrect.
+      // Output indices of the top left and bottom right corners of the subrect.
 
       var opbeg = (frame.y * width + frame.x) * 4;
       var opend = ((frame.y + frame.height) * width + frame.x) * 4;

--- a/dist/jspdf.debug.js
+++ b/dist/jspdf.debug.js
@@ -7038,7 +7038,7 @@
         }
       });
       /**
-       * (PDF 1.2) If set, print the annotation when the page is printed. If clear, never print the annotation, regardless of wether is is displayed on the screen.
+       * (PDF 1.2) If set, print the annotation when the page is printed. If clear, never print the annotation, regardless of whether is is displayed on the screen.
        * NOTE 2 This can be useful for annotations representing interactive pushbuttons, which would serve no meaningful purpose on the printed page.
        *
        * @name AcroFormField#showWhenPrinted

--- a/dist/jspdf.node.debug.js
+++ b/dist/jspdf.node.debug.js
@@ -6557,7 +6557,7 @@ var jsPDF = function (global) {
       }
     });
     /**
-     * (PDF 1.2) If set, print the annotation when the page is printed. If clear, never print the annotation, regardless of wether is is displayed on the screen.
+     * (PDF 1.2) If set, print the annotation when the page is printed. If clear, never print the annotation, regardless of whether is is displayed on the screen.
      * NOTE 2 This can be useful for annotations representing interactive pushbuttons, which would serve no meaningful purpose on the printed page.
      *
      * @name AcroFormField#showWhenPrinted

--- a/src/libs/omggif.js
+++ b/src/libs/omggif.js
@@ -627,7 +627,7 @@ function GifReader(buf) {
     var framestride = width - framewidth;
     var xleft = framewidth; // Number of subrect pixels left in scanline.
 
-    // Output indicies of the top left and bottom right corners of the subrect.
+    // Output indices of the top left and bottom right corners of the subrect.
     var opbeg = (frame.y * width + frame.x) * 4;
     var opend = ((frame.y + frame.height) * width + frame.x) * 4;
     var op = opbeg;
@@ -699,7 +699,7 @@ function GifReader(buf) {
     var framestride = width - framewidth;
     var xleft = framewidth; // Number of subrect pixels left in scanline.
 
-    // Output indicies of the top left and bottom right corners of the subrect.
+    // Output indices of the top left and bottom right corners of the subrect.
     var opbeg = (frame.y * width + frame.x) * 4;
     var opend = ((frame.y + frame.height) * width + frame.x) * 4;
     var op = opbeg;

--- a/src/modules/acroform.js
+++ b/src/modules/acroform.js
@@ -964,7 +964,7 @@
     });
 
     /**
-     * (PDF 1.2) If set, print the annotation when the page is printed. If clear, never print the annotation, regardless of wether is is displayed on the screen.
+     * (PDF 1.2) If set, print the annotation when the page is printed. If clear, never print the annotation, regardless of whether is is displayed on the screen.
      * NOTE 2 This can be useful for annotations representing interactive pushbuttons, which would serve no meaningful purpose on the printed page.
      *
      * @name AcroFormField#showWhenPrinted


### PR DESCRIPTION
There is a small typo in dist/jspdf.debug.js, dist/jspdf.node.debug.js, src/modules/acroform.js.

Should read `whether` rather than `wether`.

