### PR TITLE
Fixing bad API usage in font-face example

### DIFF
--- a/examples/js/font-faces.js
+++ b/examples/js/font-faces.js
@@ -1,25 +1,20 @@
-var doc = new jsPDF();
+const doc = new jsPDF();
 
 doc.text("This is the default font.", 20, 20);
 
-doc.setFont("courier");
-doc.setFontStyle("normal");
+doc.setFont("courier", "normal");
 doc.text("This is courier normal.", 20, 30);
 
-doc.setFont("times");
-doc.setFontStyle("italic");
+doc.setFont("times", "italic");
 doc.text("This is times italic.", 20, 40);
 
-doc.setFont("helvetica");
-doc.setFontStyle("bold");
+doc.setFont("helvetica", "bold");
 doc.text("This is helvetica bold.", 20, 50);
 
-doc.setFont("courier");
-doc.setFontStyle("bolditalic");
+doc.setFont("courier", "bolditalic");
 doc.text("This is courier bolditalic.", 20, 60);
 
-doc.setFont("times");
-doc.setFontStyle("normal");
+doc.setFont("times", "normal");
 doc.text("This is centred text.", 105, 80, null, null, "center");
 doc.text("And a little bit more underneath it.", 105, 90, null, null, "center");
 doc.text("This is right aligned text", 200, 100, null, null, "right");

--- a/examples/js/string-splitting.js
+++ b/examples/js/string-splitting.js
@@ -32,17 +32,17 @@ var pageWidth = 8.5,
 // splitTextToSize takes your string and turns it in to an array of strings,
 // each of which can be displayed within the specified maxLineWidth.
 var textLines = doc
-  .setFont("helvetica", "neue")
+  .setFont("helvetica")
   .setFontSize(fontSize)
   .splitTextToSize(text, maxLineWidth);
-
+ 
 // doc.text can now add those lines easily; otherwise, it would have run text off the screen!
 doc.text(textLines, margin, margin + 2 * oneLineHeight);
 
 // You can also calculate the height of the text very simply:
 var textHeight = (textLines.length * fontSize * lineHeight) / ptsPerInch;
 doc
-  .setFontStyle("bold")
+  .setFont("Helvetica", "bold")
   .text(
     "Text Height: " + textHeight + " inches",
     margin,


### PR DESCRIPTION
The code was using `setFont` + `setFontStyle` which is now a single combined call. I am proposing a fix to the sample code, here.