### PR TITLE
Release 2.0.0 breaks the latest unpkg  jspdf.*.js URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Alternatively, load it from a CDN:
 Or always get latest version via [unpkg](https://unpkg.com/#/)
 
 ```html
-<script src="https://unpkg.com/jspdf@latest/dist/jspdf.min.js"></script>
+<script src="https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js"></script>
 ```
 
 The `dist` folder of this package contains different kinds of files:

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,7 @@ yarn add jspdf
 <pre class="prettyprint source lang-html"><code>&lt;script src=&quot;https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.0.0/jspdf.umd.min.js&quot;>&lt;/script>
 </code></pre>
 <p>Or always get latest version via <a href="https://unpkg.com/#/">unpkg</a></p>
-<pre class="prettyprint source lang-html"><code>&lt;script src=&quot;https://unpkg.com/jspdf@latest/dist/jspdf.min.js&quot;>&lt;/script>
+<pre class="prettyprint source lang-html"><code>&lt;script src=&quot;https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js&quot;>&lt;/script>
 </code></pre>
 <p>The <code>dist</code> folder of this package contains different kinds of files:</p>
 <ul>


### PR DESCRIPTION
Updated the [unpkg](https://unpkg.com/) `latest` build URL in the readme & docs to point to the umd minified script.