### PR TITLE
parse data to string if cell value number

### DIFF
--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -377,6 +377,23 @@ import { jsPDF } from "../jspdf.js";
 
     config = config || {};
 
+    if (!config.cellValueStringOnly) {
+      //parse data
+      data = data.map(function(d) {
+        var newD = {};
+        Object.keys(d)
+          .map(function(key) {
+            return [key, d[key]];
+          })
+          .forEach(function(item) {
+            var key = item[0];
+            var value = item[1];
+            newD[key] = typeof value === "number" ? String(value) : value;
+          });
+        return newD;
+      });
+    }
+
     var headerNames = [],
       headerLabels = [],
       headerAligns = [],

--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -381,15 +381,10 @@ import { jsPDF } from "../jspdf.js";
       //parse data
       data = data.map(function(d) {
         var newD = {};
-        Object.keys(d)
-          .map(function(key) {
-            return [key, d[key]];
-          })
-          .forEach(function(item) {
-            var key = item[0];
-            var value = item[1];
-            newD[key] = typeof value === "number" ? String(value) : value;
-          });
+        Object.keys(d).forEach(function(key) {
+          var value = d[key];
+          newD[key] = typeof value === "number" ? String(value) : value;
+        });
         return newD;
       });
     }


### PR DESCRIPTION
when the value is a number column is coming empty ( this PR  #2872  could not fix it entirely which fixed this issue #2849  ).

for example in this setting coin value to a number is making the col empty.
<img width="699" alt="Screenshot 2020-08-26 at 12 26 13 PM" src="https://user-images.githubusercontent.com/11574135/91278757-3ea5e880-e7a2-11ea-8500-a9b5d27840a3.png">

so in this PR parsing data. user can turn it off if want or all data cell values are string /array of string.
by passing config.cellValueStringOnly to table function