### PR TITLE
Use any[] for untyped array instead of []

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1331,7 +1331,7 @@ declare module "jspdf" {
   }
 
   export interface jsPDFAPI {
-    events: [];
+    events: any[];
   }
 
   export default jsPDF;


### PR DESCRIPTION
Fixes a typescript compiler error: "A tuple type element list cannot be empty"