### PR TITLE
Added x and y to the type on HTMLOptions

### DIFF
--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -969,8 +969,14 @@ import { globalObject } from "../libs/globalObject.js";
    * @param {HTMLElement|string} source The source HTMLElement or a string containing HTML.
    * @param {Object} [options] Collection of settings
    * @param {function} [options.callback] The mandatory callback-function gets as first parameter the current jsPDF instance
-   * @param {function} [options.x] x position on the PDF document
-   * @param {function} [options.y] y position on the PDF document
+   * @param {number|array} [options.margin] Array of margins [left, bottom, right, top]
+   * @param {string} [options.filename] name of the file 
+   * @param {boolean} [options.enableLinks] should links work in the HTML when added to the PDF 
+   * @param {HTMLOptionImage} [options.image] image settings when converting HTML to image 
+   * @param {Html2CanvasOptions} [options.html2canvas] html2canvas options
+   * @param {jsPDF} [options.jsPDF] jsPDF instance
+   * @param {number} [options.x] x position on the PDF document
+   * @param {number} [options.y] y position on the PDF document
    *
    * @example
    * var doc = new jsPDF();

--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -969,6 +969,8 @@ import { globalObject } from "../libs/globalObject.js";
    * @param {HTMLElement|string} source The source HTMLElement or a string containing HTML.
    * @param {Object} [options] Collection of settings
    * @param {function} [options.callback] The mandatory callback-function gets as first parameter the current jsPDF instance
+   * @param {function} [options.x] x position on the PDF document
+   * @param {function} [options.y] y position on the PDF document
    *
    * @example
    * var doc = new jsPDF();
@@ -977,6 +979,8 @@ import { globalObject } from "../libs/globalObject.js";
    *    callback: function (doc) {
    *      doc.save();
    *    }
+   *    x: 10,
+   *    y: 10
    * });
    */
   jsPDFAPI.html = function(src, options) {

--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -978,7 +978,7 @@ import { globalObject } from "../libs/globalObject.js";
    * doc.html(document.body, {
    *    callback: function (doc) {
    *      doc.save();
-   *    }
+   *    },
    *    x: 10,
    *    y: 10
    * });

--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -971,7 +971,6 @@ import { globalObject } from "../libs/globalObject.js";
    * @param {function} [options.callback] The mandatory callback-function gets as first parameter the current jsPDF instance
    * @param {number|array} [options.margin] Array of margins [left, bottom, right, top]
    * @param {string} [options.filename] name of the file 
-   * @param {boolean} [options.enableLinks] should links work in the HTML when added to the PDF 
    * @param {HTMLOptionImage} [options.image] image settings when converting HTML to image 
    * @param {Html2CanvasOptions} [options.html2canvas] html2canvas options
    * @param {jsPDF} [options.jsPDF] jsPDF instance

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -198,6 +198,8 @@ declare module "jspdf" {
     image?: HTMLOptionImage;
     html2canvas?: Html2CanvasOptions;
     jsPDF?: jsPDF;
+    x?: number;
+    y?: number;
   }
 
   //jsPDF plugin: viewerPreferences

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -182,19 +182,10 @@ declare module "jspdf" {
     quality: number;
   }
 
-  export interface HTMLOptionPageBreak {
-    mode?: "avoid-all" | "css" | "legacy" | ("avoid-all" | "css" | "legacy")[];
-    before?: string;
-    after?: string;
-    avoid?: string;
-  }
-
   export interface HTMLOptions {
     callback?: (doc: jsPDF) => void;
     margin?: number | number[];
     filename?: string;
-    enableLinks?: boolean;
-    pagebreak?: HTMLOptionPageBreak;
     image?: HTMLOptionImage;
     html2canvas?: Html2CanvasOptions;
     jsPDF?: jsPDF;


### PR DESCRIPTION
Noticed when using the library that it accepts x and y on `.html` as options however these are not in the types on HTMLOptions.