### PR TITLE
add a default scale to html2canvas

### DIFF
--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -427,6 +427,8 @@ import { globalObject } from "../libs/globalObject.js";
         // Handle old-fashioned 'onrendered' argument.
 
         var pdf = this.opt.jsPDF;
+        var defaultScale = (pdf.internal.pageSize.width - this.opt.x * 2) / this.prop.src.scrollWidth;
+        this.opt.html2canvas.scale = this.opt.html2canvas.scale || defaultScale;
         var options = Object.assign(
           {
             async: true,


### PR DESCRIPTION
this helps to solve the default unit issue, which uses mm instead of pt, and issues #2911, #2907, and possibly #2885 and #2909.