### PR TITLE
Update addImage input param(compression) type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -848,7 +848,7 @@ declare module "jspdf" {
       w: number,
       h: number,
       alias?: string,
-      compression?: ImageCompression,
+      compression?: "NONE" | "FAST" | "MEDIUM" | "SLOW",
       rotation?: number
     ): jsPDF;
     addImage(


### PR DESCRIPTION
Here the Issue on `addImage` parameter `compression` data type error fixed.
It initially throws error on entering string type params.