### PR TITLE
Fix multiline text not preserved when using "maxWidth" property

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -3531,7 +3531,9 @@ function jsPDF(options) {
       if (typeof text === "string") {
         text = scope.splitTextToSize(text, maxWidth);
       } else if (Object.prototype.toString.call(text) === "[object Array]") {
-        text = scope.splitTextToSize(text.join(" "), maxWidth);
+        text = text.reduce(function(acc, textLine) {
+          return acc.concat(scope.splitTextToSize(textLine, maxWidth));
+        }, []);
       }
     }
 

--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -202,7 +202,9 @@ import { jsPDF } from "../jspdf.js";
       if (typeof text === "string") {
         text = this.splitTextToSize(text, maxWidth);
       } else if (Object.prototype.toString.call(text) === "[object Array]") {
-        text = this.splitTextToSize(text.join(" "), maxWidth);
+        text = text.reduce(function(acc, textLine) {
+          return acc.concat(scope.splitTextToSize(textLine, maxWidth));
+        }, []);
       }
     } else {
       // Without the else clause, it will not work if you do not pass along maxWidth
@@ -558,18 +560,9 @@ import { jsPDF } from "../jspdf.js";
 
     return Object.keys(model)
       .map(function(key) {
-        return [key, model[key]];
-      })
-      .map(function(item) {
-        var key = item[0];
-        var value = item[1];
-        return typeof value === "object" ? [key, value.text] : [key, value];
-      })
-      .map(function(item) {
-        var key = item[0];
-        var value = item[1];
+        var value = model[key];
         return this.splitTextToSize(
-          value,
+          value.hasOwnProperty("text") ? value.text : value,
           columnWidths[key] - padding - padding
         );
       }, this)

--- a/test/specs/cell.spec.js
+++ b/test/specs/cell.spec.js
@@ -26,6 +26,12 @@ describe("Module: Cell", () => {
     expect(
       doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 100 }).w
     ).toEqual(96.64000000000001);
+    expect(
+      doc.getTextDimensions("Octocat loves jsPDF\njsPDF loves Octocat", { maxWidth: 100 }).h
+    ).toEqual(71.19999999999999);
+    expect(
+      doc.getTextDimensions("Octocat loves jsPDF\njsPDF loves Octocat", { maxWidth: 100 }).w
+    ).toEqual(96.64000000000001);
     expect(doc.getTextDimensions("").w).toEqual(0);
     expect(doc.getTextDimensions("").h).toEqual(0);
     expect(doc.getTextDimensions([""]).w).toEqual(0);

--- a/test/specs/jspdf.unit.spec.js
+++ b/test/specs/jspdf.unit.spec.js
@@ -2491,6 +2491,35 @@ break`,
         "ET"
       ].join("\n")
     ]);
+
+    //check for maxWidth-functionality - has to split, preserving multiline;
+    doc = jsPDF({ floatPrecision: 2 });
+    writeArray = [];
+    doc.__private__.setCustomOutputDestination(writeArray);
+    doc.__private__.text(
+      `This is a test.
+This is a test too.`,
+      10,
+      10,
+      {
+        scope: doc,
+        maxWidth: 30
+      }
+    );
+    expect(writeArray).toEqual([
+      [
+        "BT",
+        "/F1 16 Tf",
+        "18.4 TL",
+        "0 g",
+        "28.35 813.54 Td",
+        "(This is a) Tj",
+        "T* (test.) Tj",
+        "T* (This is a) Tj",
+        "T* (test too.) Tj",
+        "ET"
+      ].join("\n")
+    ]);
   });
 
   it("jsPDF private function setLineCap", () => {


### PR DESCRIPTION
There was a problem when using multiline text and `maxWidth` text property simultameously, `maxWidth` was kind of rewriting existing text line splitting. It could be seen with multiline text inside table cell (#2891) or just with ordinary text like this:
```
doc.setFontSize(16);
doc.text("This is first line.\nThis is next line.", 20, 20, {"maxWidth": 25});
doc.text(["This is first line.","This is next line."], 20, 60, {"maxWidth": 25});
```

With this PR lines of text defined by user are preserved when putting width restriction on them. It works for both multiline-as-an-array and multiline-as-formatted-with-linebreak-symbols texts. Also cell line height calculation was fixed, so that it works for both variants described above.

There is String Splitting example in live demo, it works correctly, but looks like it uses `splitTextToSize` method directly.

Basic checks done:
- [x] different combinations checked manually in Live Demo
- [x] two problem-specific unit tests are added
- [x] `npm run test-local` pass except one test (which is not passing in master branch for me as well, so probably it is my local browser-related problem or whatever)