### PR TITLE
fix #2938: textWithLink -> link centered correctly

### DIFF
--- a/dist/jspdf.umd.js
+++ b/dist/jspdf.umd.js
@@ -10718,8 +10718,9 @@
       this.text(text, x, y, options);
       //TODO We really need the text baseline height to do this correctly.
       // Or ability to draw text on top, bottom, center, or baseline.
+      x += width * 0.5;
       y += height * 0.2;
-      this.link(x, y - height, width, height, options);
+      this.link(x - width, y - height, width, height, options);
       return width;
     };
 


### PR DESCRIPTION
I saw the issue of the link not centered on the text.
I only changed it in the jspdf.umd.js file.
Is it necessary to change it in the other files?