### PR TITLE
bump dep on dompurify to pickup fixes for cve-2020-7691

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3330,9 +3330,9 @@
       "dev": true
     },
     "dompurify": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.12.tgz",
-      "integrity": "sha512-Fl8KseK1imyhErHypFPA8qpq9gPzlsJ/EukA6yk9o0gX23p1TzC+rh9LqNg1qvErRTc0UNMYlKxEGSfSh43NDg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.0.tgz",
+      "integrity": "sha512-bqFOQ7XRmmozp0VsKdIEe8UwZYxj0yttz7l80GBtBqdVRY48cOpXH2J/CVO7AEkV51qY0EBVXfilec18mdmQ/w==",
       "optional": true
     },
     "dot-case": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "optionalDependencies": {
     "canvg": "^3.0.6",
     "core-js": "^3.6.0",
-    "dompurify": "^2.0.12",
+    "dompurify": "^2.2.0",
     "html2canvas": "^1.0.0-rc.5"
   },
   "devDependencies": {


### PR DESCRIPTION
See #2971 

Side note, if you run on an npm audit, theres a few high errors coming from a sub dependency on bl coming from karma-sauce-launcher, and those should probably be fixed as well