### PR TITLE
Fix instable tests

### DIFF
--- a/test/specs/encryption.spec.js
+++ b/test/specs/encryption.spec.js
@@ -9,20 +9,19 @@
 describe("Core: Standard Encryption", () => {
   beforeAll(loadGlobals);
   it("should allow text insertion", () => {
-    const doc = jsPDF({ 
+    const doc = jsPDF({
       floatPrecision: 2,
       encryption: {
         userPassword: "password"
       }
     });
     doc.__private__.setFileId("0000000000000000000000000BADFACE");
+    doc.__private__.setCreationDate("D:19871210000000+00'00'");
     doc.text(10, 10, "This is a test!");
     comparePdf(doc.output(), "encrypted_standard.pdf", "encryption");
-    doc.internal.encryption = null;
-    doc.internal.encryptionOptions = null;
   });
   it("should be printable", () => {
-    const doc = jsPDF({ 
+    const doc = jsPDF({
       floatPrecision: 2,
       encryption: {
         userPassword: "password",
@@ -30,10 +29,9 @@ describe("Core: Standard Encryption", () => {
       }
     });
     doc.__private__.setFileId("0000000000000000000000000BADFACE");
+    doc.__private__.setCreationDate("D:19871210000000+00'00'");
     doc.text(10, 10, "This is a test!");
     comparePdf(doc.output(), "encrypted_printable.pdf", "encryption");
-    doc.internal.encryption = null;
-    doc.internal.encryptionOptions = null;
   });
   it("should display forms properly", () => {
     var doc = new jsPDF({
@@ -41,6 +39,7 @@ describe("Core: Standard Encryption", () => {
       encryption: {}
     });
     doc.__private__.setFileId("0000000000000000000000000BADFACE");
+    doc.__private__.setCreationDate("D:19871210000000+00'00'");
     var {
       ComboBox,
       ListBox,
@@ -49,7 +48,7 @@ describe("Core: Standard Encryption", () => {
       TextField,
       PasswordField,
       RadioButton,
-      Appearance,
+      Appearance
     } = jsPDF.AcroForm;
 
     doc.setFontSize(12);
@@ -112,14 +111,9 @@ describe("Core: Standard Encryption", () => {
     var radioButton3 = radioGroup.createOption("Test3");
     radioButton3.Rect = [50, 190, 20, 10];
     radioGroup.setAppearance(Appearance.RadioButton.Cross);
-    
-    comparePdf(
-      doc.output(),
-      "encrypted_withAcroForm.pdf",
-      "encryption"
-    );
 
-  })
+    comparePdf(doc.output(), "encrypted_withAcroForm.pdf", "encryption");
+  });
   it("colortype_3_indexed_single_colour_alpha_4_bit_png", () => {
     var colortype_3_indexed_single_colour_alpha_4_bit_png =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAG1BMVEX/////AAD/pQD//wAA/wAAgAAAgIAAAP+BAIC08EFzAAAAAXRSTlMAQObYZgAAAJtJREFUCB0BkABv/wAREQAAAAAAAAAiIhEQAAAAAAAzMyIhEAAAAABERDMyIQAAAABVVUQzIhAAAABmZlVEMyEAAAB3d2ZVQzIQAACIh3dlVDIhAAAACId2VUMhAAAAAAiHZUMyEAAAAACHdlQyEAAAAAAIdlQyEAAAAAAId2VDIQAAAAAAh2VDIQAAAAAAh2VDIQAAAAAAh2VDIWfgFTHZzlYNAAAAAElFTkSuQmCC";
@@ -134,6 +128,7 @@ describe("Core: Standard Encryption", () => {
       }
     });
     doc.__private__.setFileId("0000000000000000000000000BADFACE");
+    doc.__private__.setCreationDate("D:19871210000000+00'00'");
     doc.addImage(
       colortype_3_indexed_single_colour_alpha_4_bit_png,
       "PNG",
@@ -144,12 +139,6 @@ describe("Core: Standard Encryption", () => {
       undefined,
       undefined
     );
-    comparePdf(
-      doc.output(),
-      "encrypted_withImage.pdf",
-      "encryption"
-    );
-    doc.internal.encryption = null;
-    doc.internal.encryptionOptions = null;
+    comparePdf(doc.output(), "encrypted_withImage.pdf", "encryption");
   });
 });

--- a/test/specs/putTotalPages.spec.js
+++ b/test/specs/putTotalPages.spec.js
@@ -41,91 +41,89 @@ describe("Module: putTotalPages", () => {
 
     comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
   });
-});
 
-it("customfont with encoding without passing fontWeight", () => {
-  var PTSans = loadBinaryResource("reference/PTSans.ttf");
-  var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
-  var totalPagesExp = "{totalPages}";
+  it("customfont with encoding without passing fontWeight", () => {
+    var PTSans = loadBinaryResource("reference/PTSans.ttf");
+    var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
+    var totalPagesExp = "{totalPages}";
 
-  doc.addFileToVFS("PTSans.ttf", PTSans);
-  doc.addFont("PTSans.ttf", "PTSans", "normal", "Identity-H");
+    doc.addFileToVFS("PTSans.ttf", PTSans);
+    doc.addFont("PTSans.ttf", "PTSans", "normal", "Identity-H");
 
-  doc.setFont("PTSans");
+    doc.setFont("PTSans");
 
-  doc.text(10, 10, "Page 1 of {totalPages}");
-  doc.addPage();
+    doc.text(10, 10, "Page 1 of {totalPages}");
+    doc.addPage();
 
-  doc.text(10, 10, "Page 2 of {totalPages}");
+    doc.text(10, 10, "Page 2 of {totalPages}");
 
-  if (typeof doc.putTotalPages === "function") {
-    doc.putTotalPages(totalPagesExp);
-  }
+    if (typeof doc.putTotalPages === "function") {
+      doc.putTotalPages(totalPagesExp);
+    }
 
-  comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
-});
+    comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
+  });
 
+  it("customfont check without passing fontweight in setfont", () => {
+    var PTSans = loadBinaryResource("reference/PTSans.ttf");
+    var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
+    var totalPagesExp = "{totalPages}";
 
-it("customfont check without passing fontweight in setfont", () => {
-  var PTSans = loadBinaryResource("reference/PTSans.ttf");
-  var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
-  var totalPagesExp = "{totalPages}";
+    doc.addFileToVFS("PTSans.ttf", PTSans);
+    doc.addFont("PTSans.ttf", "PTSans", "normal");
 
-  doc.addFileToVFS("PTSans.ttf", PTSans);
-  doc.addFont("PTSans.ttf", "PTSans", "normal");
+    doc.setFont("PTSans", "normal");
 
-  doc.setFont("PTSans",'normal');
+    doc.text(10, 10, "Page 1 of {totalPages}");
+    doc.addPage();
 
-  doc.text(10, 10, "Page 1 of {totalPages}");
-  doc.addPage();
+    doc.text(10, 10, "Page 2 of {totalPages}");
 
-  doc.text(10, 10, "Page 2 of {totalPages}");
+    if (typeof doc.putTotalPages === "function") {
+      doc.putTotalPages(totalPagesExp);
+    }
+    comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
+  });
 
-  if (typeof doc.putTotalPages === "function") {
-    doc.putTotalPages(totalPagesExp);
-  }
-  comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
-});
+  it("customfont with fontweight", () => {
+    var PTSans = loadBinaryResource("reference/PTSans.ttf");
+    var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
+    var totalPagesExp = "{totalPages}";
 
+    doc.addFileToVFS("PTSans.ttf", PTSans);
+    doc.addFont("PTSans.ttf", "PTSans", "normal", 200, "Identity-H");
 
-it("customfont with fontweight", () => {
-  var PTSans = loadBinaryResource("reference/PTSans.ttf");
-  var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
-  var totalPagesExp = "{totalPages}";
+    doc.setFont("PTSans", "normal", 200);
 
-  doc.addFileToVFS("PTSans.ttf", PTSans);
-  doc.addFont("PTSans.ttf", "PTSans", "normal",200, "Identity-H");
+    doc.text(10, 10, "Page 1 of {totalPages}");
+    doc.addPage();
 
-  doc.setFont("PTSans",'normal',200);
+    doc.text(10, 10, "Page 2 of {totalPages}");
 
-  doc.text(10, 10, "Page 1 of {totalPages}");
-  doc.addPage();
+    if (typeof doc.putTotalPages === "function") {
+      doc.putTotalPages(totalPagesExp);
+    }
+    comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
+  });
 
-  doc.text(10, 10, "Page 2 of {totalPages}");
+  it("customfont with samevalue in fontweight and fontstyle ", () => {
+    var PTSans = loadBinaryResource("reference/PTSans.ttf");
+    var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
+    var totalPagesExp = "{totalPages}";
 
-  if (typeof doc.putTotalPages === "function") {
-    doc.putTotalPages(totalPagesExp);
-  }
-  comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
-});
+    doc.addFileToVFS("PTSans.ttf", PTSans);
+    doc.addFont("PTSans.ttf", "PTSans", "normal", "normal", "Identity-H");
 
-it("customfont with samevalue in fontweight and fontstyle ", () => {
-  var PTSans = loadBinaryResource("reference/PTSans.ttf");
-  var doc = new jsPDF({ filters: ["ASCIIHexEncode"], floatPrecision: 2 });
-  var totalPagesExp = "{totalPages}";
+    doc.setFont("PTSans", "normal", "normal");
 
-  doc.addFileToVFS("PTSans.ttf", PTSans);
-  doc.addFont("PTSans.ttf", "PTSans", "normal", "normal", "Identity-H");
+    doc.text(10, 10, "Page 1 of {totalPages}");
+    doc.addPage();
 
-  doc.setFont("PTSans",'normal', "normal");
+    doc.text(10, 10, "Page 2 of {totalPages}");
 
-  doc.text(10, 10, "Page 1 of {totalPages}");
-  doc.addPage();
-
-  doc.text(10, 10, "Page 2 of {totalPages}");
-
-  if (typeof doc.putTotalPages === "function") {
-    doc.putTotalPages(totalPagesExp);
-  }
-  comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
+    if (typeof doc.putTotalPages === "function") {
+      doc.putTotalPages(totalPagesExp);
+    }
+    comparePdf(doc.output(), "customfont.pdf", "putTotalPages");
+  });
 });


### PR DESCRIPTION
* encryption tests were instable because different dates might result in different lengths of the `/CreationDate` encrypted string, resulting in different offsets for the Catalog dictionary and startxref
* fix nesting of tests introduced in #3036