### PR TITLE
fix(FileSaver): HTMLAnchorElement is not defined

### DIFF
--- a/src/libs/FileSaver.js
+++ b/src/libs/FileSaver.js
@@ -89,8 +89,8 @@ var saveAs =
     ? function saveAs() {
         /* noop */
       }
-    : // Use download attribute first if possible (#193 Lumia mobile)
-    "download" in HTMLAnchorElement.prototype
+    : // Use download attribute first if possible (#193 Lumia mobile) unless this is a native app
+    (typeof HTMLAnchorElement !== "undefined" && "download" in HTMLAnchorElement.prototype)
     ? function saveAs(blob, name, opts) {
         var URL = _global.URL || _global.webkitURL;
         var a = document.createElement("a");


### PR DESCRIPTION
This PR fixes this issue: https://github.com/MrRio/jsPDF/issues/3072

It will prevent React Native apps from crashing because of FileSaver.js. As mentioned in the issue this change is already included in the latest version of FileSaver.
