### PR TITLE
fix the ReDoS-vulnerable regexp

### DIFF
--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -630,7 +630,7 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
     var result = null;
 
     if (dataUrlParts.length === 2) {
-      var extractedInfo = /^data:(\w*\/\w*);*(charset=[\w=-]*)*;*$/.exec(
+      var extractedInfo = /^data:(\w*\/\w*);*(charset=(?!charset=)[\w=-]*)*;*$/.exec(
         dataUrlParts[0]
       );
       if (Array.isArray(extractedInfo)) {


### PR DESCRIPTION
fix the ReDoS-vulnerable [regexp](https://github.com/MrRio/jsPDF/blob/master/src/modules/addimage.js#L633) in addimage.js

see #3090 



