### PR TITLE
A readme change regarding unicode fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ const myFont = ... // load the *.ttf font file as binary string
 // add the font to jsPDF
 doc.addFileToVFS("MyFont.ttf", myFont);
 doc.addFont("MyFont.ttf", "MyFont", "normal");
+doc.setFont("MyFont");
 ```
 
 ## Advanced Functionality


### PR DESCRIPTION
Until using `setFont(...)` the font is not changed. It would be more clear if add this line too. 
