### PR TITLE
Improve performance of arrayBufferToBinaryString

### DIFF
--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -43,9 +43,9 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
 
   var UNKNOWN = "UNKNOWN";
 
-  // Heuristic limit after which String.fromCharCode will start to overflow.
-  // Need to change to StringDecoder.
-  var ARRAY_BUFFER_LIMIT = 6000000;
+  // Heuristic selection after which String.fromCharCode will start to overflow. Below will be slow as more calls are made.
+  // higher values cause larged and slower garbage collection
+  var ARRAY_BUFFER_BATCH = 8192;
 
   var imageFileTypeHeaders = {
     PNG: [[0x89, 0x50, 0x4e, 0x47]],
@@ -736,11 +736,11 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
   ) {
     var out = "";
     var u8buf = new Uint8Array(buffer);
-    for (var i = 0; i < u8buf.length; i += ARRAY_BUFFER_LIMIT) {
+    for (var i = 0; i < u8buf.length; i += ARRAY_BUFFER_BATCH) {
       // Limit the amount of characters being parsed to prevent overflow.
       // Note that while TextDecoder would be faster, it does not have the same
       // functionality as fromCharCode with any provided encodings as of 3/2021.
-      out += String.fromCharCode.apply(null, u8buf.subarray(i, i + ARRAY_BUFFER_LIMIT));
+      out += String.fromCharCode.apply(null, u8buf.subarray(i, i + ARRAY_BUFFER_BATCH));
     }
     return out;
   });

--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -45,7 +45,7 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
 
   // Heuristic selection of a good batch for large array .apply. Not limiting make the call overflow.
   // With too small batch iteration will be slow as more calls are made,
-  // Higher values cause larged and slower garbage collection.
+  // higher values cause larger and slower garbage collection.
   var ARRAY_APPLY_BATCH = 8192;
 
   var imageFileTypeHeaders = {
@@ -728,7 +728,7 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
    * @name arrayBufferToBinaryString
    * @public
    * @function
-   * @param {ArrayBuffer} ArrayBuffer with ImageData
+   * @param {ArrayBuffer|ArrayBufferView} ArrayBuffer buffer or bufferView with ImageData
    *
    * @returns {String}
    */
@@ -736,14 +736,16 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
     buffer
   ) {
     var out = "";
-    var u8buf = new Uint8Array(buffer);
-    for (var i = 0; i < u8buf.length; i += ARRAY_APPLY_BATCH) {
+    // There are calls with both ArrayBuffer and already converted Uint8Array or other BufferView.
+    // Do not copy the array if input is already an array.
+    var buf = isArrayBufferView(buffer) ? buffer : new Uint8Array(buffer);
+    for (var i = 0; i < buf.length; i += ARRAY_APPLY_BATCH) {
       // Limit the amount of characters being parsed to prevent overflow.
       // Note that while TextDecoder would be faster, it does not have the same
       // functionality as fromCharCode with any provided encodings as of 3/2021.
       out += String.fromCharCode.apply(
         null,
-        u8buf.subarray(i, i + ARRAY_APPLY_BATCH)
+        buf.subarray(i, i + ARRAY_APPLY_BATCH)
       );
     }
     return out;

--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -43,9 +43,10 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
 
   var UNKNOWN = "UNKNOWN";
 
-  // Heuristic selection after which String.fromCharCode will start to overflow. Below will be slow as more calls are made.
-  // higher values cause larged and slower garbage collection
-  var ARRAY_BUFFER_BATCH = 8192;
+  // Heuristic selection of a good batch for large array .apply. Not limiting make the call overflow.
+  // With too small batch iteration will be slow as more calls are made,
+  // Higher values cause larged and slower garbage collection.
+  var ARRAY_APPLY_BATCH = 8192;
 
   var imageFileTypeHeaders = {
     PNG: [[0x89, 0x50, 0x4e, 0x47]],
@@ -736,11 +737,11 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
   ) {
     var out = "";
     var u8buf = new Uint8Array(buffer);
-    for (var i = 0; i < u8buf.length; i += ARRAY_BUFFER_BATCH) {
+    for (var i = 0; i < u8buf.length; i += ARRAY_APPLY_BATCH) {
       // Limit the amount of characters being parsed to prevent overflow.
       // Note that while TextDecoder would be faster, it does not have the same
       // functionality as fromCharCode with any provided encodings as of 3/2021.
-      out += String.fromCharCode.apply(null, u8buf.subarray(i, i + ARRAY_BUFFER_BATCH));
+      out += String.fromCharCode.apply(null, u8buf.subarray(i, i + ARRAY_APPLY_BATCH));
     }
     return out;
   });

--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -741,7 +741,10 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
       // Limit the amount of characters being parsed to prevent overflow.
       // Note that while TextDecoder would be faster, it does not have the same
       // functionality as fromCharCode with any provided encodings as of 3/2021.
-      out += String.fromCharCode.apply(null, u8buf.subarray(i, i + ARRAY_APPLY_BATCH));
+      out += String.fromCharCode.apply(
+        null,
+        u8buf.subarray(i, i + ARRAY_APPLY_BATCH)
+      );
     }
     return out;
   });


### PR DESCRIPTION
Thanks for the awesome library which seems to be the only way we can output snapshot of a DOM node reliably with extra headers and custom scaling options.

However we stumbled on a problem with CSP rules regarding dataUrls when using image with image dataUrl. I transferred to use a blob url of the image but performance suffered very badly.

After some performance monitoring the worst culprit was found which is fixed in this PR.

This PR has two improvements over the old functionality
## Skip expensive buffer overflows
After blob file size starts growing, so will the time spent in trying the direct conversion of the buffer. For a buffer with a size of 14M, my 2019 core i7 Mac takes 100ms before throwing an exception. For 44M that takes 400+ms. Skip trying altogether for massive buffers. The limit could be tuned but this is roughly where the processing times start increasing and overflows begin.
The image in question is about 3840x2160 px when being added to PDF.

## Use TextDecoder when possible to speed up conversion
Along with the fix above using TextDecoder is the best option for binary string conversion. I tested direct string concatenation (worst), using predefined array size with final .join (depending on GC cycles, below and above original solution).

Code in this PR runs arrayBufferToBinaryString about 18 times faster (4700 vs 251ms and 3000 vs 153 for two of my test pages).
Old:
<img width="903" alt="Screenshot 2021-03-22 at 15 01 08" src="https://user-images.githubusercontent.com/1278277/111996559-d09c8680-8b22-11eb-8cc4-ad30d1ab41f5.png">

Updated:
<img width="1080" alt="Screenshot 2021-03-22 at 15 01 28" src="https://user-images.githubusercontent.com/1278277/111996546-cda19600-8b22-11eb-9b92-5cc360206a97.png">

The total time for adding the image is still suffering from decodePixels performance but I couldn't think of a solution to fix that.
