### PR TITLE
Fix: lineWidth is a negative number

### DIFF
--- a/src/modules/context2d.js
+++ b/src/modules/context2d.js
@@ -1722,7 +1722,7 @@ import {
     var strokeStyle = this.strokeStyle;
     var lineCap = this.lineCap;
     var oldLineWidth = this.lineWidth;
-    var lineWidth = oldLineWidth * this.ctx.transform.scaleX;
+    var lineWidth = Math.abs(oldLineWidth * this.ctx.transform.scaleX);
     var lineJoin = this.lineJoin;
 
     var origPath = JSON.parse(JSON.stringify(this.path));

--- a/test/specs/context2d.spec.js
+++ b/test/specs/context2d.spec.js
@@ -555,4 +555,32 @@ describe("Context2D: standard tests", () => {
 
     comparePdf(doc.output(), "autoPaging10Pages.pdf", "context2d");
   });
+
+  it("lineWidth should be nonnegative", ()=>{
+    var doc = new jsPDF({
+      orientation: "p",
+      unit: "pt",
+      format: "a4",
+      floatPrecision: 3
+    });
+    var ctx = doc.context2d;
+    var writeArray = [];
+    doc.__private__.setCustomOutputDestination(writeArray);
+
+    ctx.beginPath();
+    ctx.strokeStyle = "#FF0000";
+    ctx.transform(-1, 0, 0, 1, 0, 0);
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 100);
+    ctx.stroke();
+
+    expect(writeArray).toEqual([
+      "1. 0. 0. RG",
+      "1. w", // <- should be nonnegative
+      "0. 841.89 m",
+      "-100. 741.89 l",
+      "S",
+      "1. w"
+    ]);
+  });
 });


### PR DESCRIPTION
According to PDF reference 1.3 - 4.3.2

> The line width parameter specifies the thickness of the line used to stroke a path. It is a nonnegative number expressed in user space units;
