### PR TITLE
add context2d setLineDash() and lineDashOffset.

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -2001,7 +2001,7 @@ function jsPDF(options) {
       font: font,
       out: out,
       newObject: newObject,
-      putStream: putStream,
+      putStream: putStream
     });
 
     if (font.isAlreadyPutted !== true) {

--- a/src/libs/FileSaver.js
+++ b/src/libs/FileSaver.js
@@ -90,7 +90,8 @@ var saveAs =
         /* noop */
       }
     : // Use download attribute first if possible (#193 Lumia mobile) unless this is a native app
-    (typeof HTMLAnchorElement !== "undefined" && "download" in HTMLAnchorElement.prototype)
+    typeof HTMLAnchorElement !== "undefined" &&
+      "download" in HTMLAnchorElement.prototype
     ? function saveAs(blob, name, opts) {
         var URL = _global.URL || _global.webkitURL;
         var a = document.createElement("a");

--- a/src/libs/pdfname.js
+++ b/src/libs/pdfname.js
@@ -5,8 +5,11 @@
  */
 function toPDFName(str) {
   // eslint-disable-next-line no-control-regex
-  if(/[^\u0000-\u00ff]/.test(str)){ // non ascii string
-    throw new Error('Invalid PDF Name Object: ' + str + ', Only accept ASCII characters.');
+  if (/[^\u0000-\u00ff]/.test(str)) {
+    // non ascii string
+    throw new Error(
+      "Invalid PDF Name Object: " + str + ", Only accept ASCII characters."
+    );
   }
   var result = "",
     strLength = str.length;

--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -442,7 +442,10 @@ import { jsPDF } from "../jspdf.js";
       });
     }
 
-    if (autoSize || (Array.isArray(headers) && typeof headers[0] === "string")) {
+    if (
+      autoSize ||
+      (Array.isArray(headers) && typeof headers[0] === "string")
+    ) {
       var headerName;
       for (i = 0; i < headerNames.length; i += 1) {
         headerName = headerNames[i];

--- a/src/modules/context2d.js
+++ b/src/modules/context2d.js
@@ -659,6 +659,7 @@ import {
       }
     });
 
+    // Not HTML API
     Object.defineProperty(this, "lineDash", {
       get: function() {
         return this.ctx.lineDash;
@@ -688,6 +689,22 @@ import {
    */
   Context2D.prototype.setLineDash = function(dashArray) {
     this.lineDash = dashArray;
+  };
+
+  /**
+   * gets the current line dash pattern.
+   * @name getLineDash
+   * @function
+   * @returns {Array} An Array of numbers that specify distances to alternately draw a line and a gap (in coordinate space units). If the number, when setting the elements, is odd, the elements of the array get copied and concatenated. For example, setting the line dash to [5, 15, 25] will result in getting back [5, 15, 25, 5, 15, 25].
+   */
+  Context2D.prototype.getLineDash = function() {
+    if (this.lineDash.length % 2) {
+      // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getLineDash#return_value
+      return this.lineDash.concat(this.lineDash);
+    } else {
+      // The copied value is returned to prevent contamination from outside.
+      return this.lineDash.slice();
+    }
   };
 
   Context2D.prototype.fill = function() {

--- a/test/reference/lineDash.pdf
+++ b/test/reference/lineDash.pdf
@@ -1,0 +1,310 @@
+%PDF-1.3
+%ºß¬à
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.28 841.89]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 587
+>>
+stream
+0.2 w
+0 G
+5. w
+5. w
+20. 821.89 m
+200. 821.89 l
+S
+5. w
+q
+[10. 20.] 0. d
+[10. 20.] 10. d
+5. w
+20. 801.89 m
+200. 801.89 l
+S
+5. w
+[] 10. d
+[] 0. d
+5. w
+20. 781.89 m
+200. 781.89 l
+S
+5. w
+[10. 20.] 0. d
+[10. 20.] 10. d
+5. w
+20. 761.89 m
+200. 761.89 l
+S
+5. w
+q
+[] 10. d
+[] 0. d
+5. w
+20. 741.89 m
+200. 741.89 l
+S
+5. w
+Q
+0. 0. 0. rg
+0. G
+0 J
+5. w
+0 j
+[10. 20.] 10. d
+5. w
+20. 721.89 m
+200. 721.89 l
+S
+5. w
+q
+5. w
+20. 701.89 m
+200. 701.89 l
+S
+5. w
+Q
+0. 0. 0. rg
+0. G
+0 J
+5. w
+0 j
+5. w
+20. 681.89 m
+200. 681.89 l
+S
+5. w
+Q
+0. 0. 0. rg
+0. G
+0 J
+5. w
+0 j
+[] 0. d
+5. w
+20. 661.89 m
+200. 661.89 l
+S
+5. w
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+6 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+7 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+9 0 obj
+<<
+/Type /Font
+/BaseFont /Courier
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+10 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+11 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+13 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+15 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+16 0 obj
+<<
+/Type /Font
+/BaseFont /Times-BoldItalic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+17 0 obj
+<<
+/Type /Font
+/BaseFont /ZapfDingbats
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+18 0 obj
+<<
+/Type /Font
+/BaseFont /Symbol
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+/F2 6 0 R
+/F3 7 0 R
+/F4 8 0 R
+/F5 9 0 R
+/F6 10 0 R
+/F7 11 0 R
+/F8 12 0 R
+/F9 13 0 R
+/F10 14 0 R
+/F11 15 0 R
+/F12 16 0 R
+/F13 17 0 R
+/F14 18 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+19 0 obj
+<<
+/Producer (jsPDF 0.0.0)
+/CreationDate (D:19871210000000+00'00')
+>>
+endobj
+20 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 21
+0000000000 65535 f 
+0000000762 00000 n 
+0000002579 00000 n 
+0000000015 00000 n 
+0000000124 00000 n 
+0000000819 00000 n 
+0000000944 00000 n 
+0000001074 00000 n 
+0000001207 00000 n 
+0000001344 00000 n 
+0000001467 00000 n 
+0000001596 00000 n 
+0000001728 00000 n 
+0000001864 00000 n 
+0000001992 00000 n 
+0000002119 00000 n 
+0000002248 00000 n 
+0000002381 00000 n 
+0000002483 00000 n 
+0000002827 00000 n 
+0000002913 00000 n 
+trailer
+<<
+/Size 21
+/Root 20 0 R
+/Info 19 0 R
+/ID [ <00000000000000000000000000000000> <00000000000000000000000000000000> ]
+>>
+startxref
+3017
+%%EOF

--- a/test/specs/context2d.spec.js
+++ b/test/specs/context2d.spec.js
@@ -485,6 +485,81 @@ describe("Context2D: standard tests", () => {
     comparePdf(doc.output(), "moveTo_lineTo_stroke_fill.pdf", "context2d");
   });
 
+  it("context2d: setLineDash(), lineDashOffset", () => {
+    var doc = new jsPDF({
+      orientation: "p",
+      unit: "pt",
+      format: "a4",
+      floatPrecision: 2
+    });
+    var ctx = doc.context2d;
+
+    var y = 20;
+    var pad = 20;
+
+    ctx.lineWidth = 5;
+    ctx.beginPath();
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.save();
+    ctx.beginPath();
+    ctx.setLineDash([10, 20]);
+    ctx.lineDashOffset = 10;
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.beginPath();
+    ctx.setLineDash([]);
+    ctx.lineDashOffset = 0;
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.beginPath();
+    ctx.setLineDash([10, 20]);
+    ctx.lineDashOffset = 10;
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.save();
+    ctx.beginPath();
+    ctx.setLineDash([]);
+    ctx.lineDashOffset = 0;
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.restore();
+    ctx.beginPath();
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.restore();
+    ctx.beginPath();
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += pad;
+    ctx.restore();
+    ctx.beginPath();
+    ctx.moveTo(20, y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+
+    comparePdf(doc.output(), "lineDash.pdf", "context2d");
+  });
+
   it("context2d: textBaseline", () => {
     var doc = new jsPDF({
       orientation: "p",

--- a/test/specs/context2d.spec.js
+++ b/test/specs/context2d.spec.js
@@ -560,6 +560,24 @@ describe("Context2D: standard tests", () => {
     comparePdf(doc.output(), "lineDash.pdf", "context2d");
   });
 
+  it("context2d: getLineDash()", () => {
+    var doc = new jsPDF({
+      orientation: "p",
+      unit: "pt",
+      format: "a4",
+      floatPrecision: 2
+    });
+    var ctx = doc.context2d;
+
+    expect(ctx.getLineDash()).toEqual([]);
+
+    ctx.setLineDash([1, 2]);
+    expect(ctx.getLineDash()).toEqual([1, 2]);
+
+    ctx.setLineDash([1, 2, 3]);
+    expect(ctx.getLineDash()).toEqual([1, 2, 3, 1, 2, 3]);
+  });
+
   it("context2d: textBaseline", () => {
     var doc = new jsPDF({
       orientation: "p",


### PR DESCRIPTION
I added `setLineDahs()` and `lineDashOffset` to context2d.
When I ran the local test, the two tests below failed, but the base master branch also failed, so I register this PR.

```
    ✖ html loads html2canvas asynchronously
      Chrome 90.0.4430.212 (Mac OS 10.15.7)
    ✖ renders font-faces
      Chrome 90.0.4430.212 (Mac OS 10.15.7)
```