### PR TITLE
Fix 3904 contex2d font regex too restrictive

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -6043,7 +6043,9 @@ function jsPDF(options) {
     getEncryptor: getEncryptor,
     output: output,
     getNumberOfPages: getNumberOfPages,
-    get pages () { return pages },
+    get pages() {
+      return pages;
+    },
     out: out,
     f2: f2,
     f3: f3,


### PR DESCRIPTION
Previously, the regex was not allowing number in font name, now we are allowing number

fixes 3904