### PR TITLE
Do not add pages dynamically unless autoPaging is enabled

### DIFF
--- a/src/modules/context2d.js
+++ b/src/modules/context2d.js
@@ -1653,18 +1653,19 @@ import {
         sheight * factorY
       )
     );
-    var pageArray = getPagesByPath.call(this, xRect);
-    var pages = [];
-    for (var ii = 0; ii < pageArray.length; ii += 1) {
-      if (pages.indexOf(pageArray[ii]) === -1) {
-        pages.push(pageArray[ii]);
-      }
-    }
 
-    sortPages(pages);
-
-    var clipPath;
     if (this.autoPaging) {
+      var pageArray = getPagesByPath.call(this, xRect);
+      var pages = [];
+      for (var ii = 0; ii < pageArray.length; ii += 1) {
+        if (pages.indexOf(pageArray[ii]) === -1) {
+          pages.push(pageArray[ii]);
+        }
+      }
+
+      sortPages(pages);
+
+      var clipPath;
       var min = pages[0];
       var max = pages[pages.length - 1];
       for (var i = min; i < max + 1; i++) {
@@ -1870,32 +1871,32 @@ import {
     var lineWidth = Math.abs(oldLineWidth * this.ctx.transform.scaleX);
     var lineJoin = this.lineJoin;
 
-    var origPath = JSON.parse(JSON.stringify(this.path));
-    var xPath = JSON.parse(JSON.stringify(this.path));
-    var clipPath;
-    var tmpPath;
-    var pages = [];
+    if (this.autoPaging) {
+      var origPath = JSON.parse(JSON.stringify(this.path));
+      var xPath = JSON.parse(JSON.stringify(this.path));
+      var clipPath;
+      var tmpPath;
+      var pages = [];
 
-    for (var i = 0; i < xPath.length; i++) {
-      if (typeof xPath[i].x !== "undefined") {
-        var page = getPagesByPath.call(this, xPath[i]);
+      for (var i = 0; i < xPath.length; i++) {
+        if (typeof xPath[i].x !== "undefined") {
+          var page = getPagesByPath.call(this, xPath[i]);
 
-        for (var ii = 0; ii < page.length; ii += 1) {
-          if (pages.indexOf(page[ii]) === -1) {
-            pages.push(page[ii]);
+          for (var ii = 0; ii < page.length; ii += 1) {
+            if (pages.indexOf(page[ii]) === -1) {
+              pages.push(page[ii]);
+            }
           }
         }
       }
-    }
 
-    for (var j = 0; j < pages.length; j++) {
-      while (this.pdf.internal.getNumberOfPages() < pages[j]) {
-        addPage.call(this);
+      for (var j = 0; j < pages.length; j++) {
+        while (this.pdf.internal.getNumberOfPages() < pages[j]) {
+          addPage.call(this);
+        }
       }
-    }
-    sortPages(pages);
+      sortPages(pages);
 
-    if (this.autoPaging) {
       var min = pages[0];
       var max = pages[pages.length - 1];
       for (var k = min; k < max + 1; k++) {
@@ -1959,12 +1960,12 @@ import {
         }
         this.lineWidth = oldLineWidth;
       }
+      this.path = origPath;
     } else {
       this.lineWidth = lineWidth;
       drawPaths.call(this, rule, isClip);
       this.lineWidth = oldLineWidth;
     }
-    this.path = origPath;
   };
 
   /**
@@ -2289,30 +2290,32 @@ import {
     var yTop = yBottom - textDimensions.h;
 
     var pt = this.ctx.transform.applyToPoint(new Point(options.x, yBaseLine));
-    var decomposedTransformationMatrix = this.ctx.transform.decompose();
-    var matrix = new Matrix();
-    matrix = matrix.multiply(decomposedTransformationMatrix.translate);
-    matrix = matrix.multiply(decomposedTransformationMatrix.skew);
-    matrix = matrix.multiply(decomposedTransformationMatrix.scale);
-
-    var baselineRect = this.ctx.transform.applyToRectangle(
-      new Rectangle(options.x, yBaseLine, textDimensions.w, textDimensions.h)
-    );
-    var textBounds = matrix.applyToRectangle(
-      new Rectangle(options.x, yTop, textDimensions.w, textDimensions.h)
-    );
-    var pageArray = getPagesByPath.call(this, textBounds);
-    var pages = [];
-    for (var ii = 0; ii < pageArray.length; ii += 1) {
-      if (pages.indexOf(pageArray[ii]) === -1) {
-        pages.push(pageArray[ii]);
-      }
-    }
-
-    sortPages(pages);
 
     var clipPath, oldSize, oldLineWidth;
+
     if (this.autoPaging) {
+      var decomposedTransformationMatrix = this.ctx.transform.decompose();
+      var matrix = new Matrix();
+      matrix = matrix.multiply(decomposedTransformationMatrix.translate);
+      matrix = matrix.multiply(decomposedTransformationMatrix.skew);
+      matrix = matrix.multiply(decomposedTransformationMatrix.scale);
+
+      var baselineRect = this.ctx.transform.applyToRectangle(
+        new Rectangle(options.x, yBaseLine, textDimensions.w, textDimensions.h)
+      );
+      var textBounds = matrix.applyToRectangle(
+        new Rectangle(options.x, yTop, textDimensions.w, textDimensions.h)
+      );
+      var pageArray = getPagesByPath.call(this, textBounds);
+      var pages = [];
+      for (var ii = 0; ii < pageArray.length; ii += 1) {
+        if (pages.indexOf(pageArray[ii]) === -1) {
+          pages.push(pageArray[ii]);
+        }
+      }
+
+      sortPages(pages);
+
       var min = pages[0];
       var max = pages[pages.length - 1];
       for (var i = min; i < max + 1; i++) {


### PR DESCRIPTION
# Do not add pages dynamically unless autoPaging is enabled

## 🐛 Problem
JsPDF might add a blank page in advance even if `autoPaging` option is not enabled.
The reason is that some branches of autoPaging-related logic are executed despite the `autoPaging` option.

## ✅ Solution
* Ensure that the appropriate branches of code are covered by checking the `autoPaging` option.

## 🧪 Pre-push checks
* ✅ `npm run build` passes
* ✅ `npm run test-unit` passes
* ✅ `npm run test-local` passes
* ✅ `npm run lint` passes