### PR TITLE
Fix incorrect page size measurement for px unit (#3921)

### DIFF
--- a/HOTFIX_README.md
+++ b/HOTFIX_README.md
@@ -16,6 +16,25 @@ new jsPDF({
 
 # Active Hotfixes
 
+## px_scaling_legacy
+
+### Applies To
+
+jsPDF Core
+
+### Description
+
+For backward compatibility, this hotfix restores the old (incorrect) pixel scaling behavior where scaleFactor = 96/72.
+By default, jsPDF now uses the correct pixel scaling (scaleFactor = 72/96) which matches the CSS standard where
+1px = 1/96in and 1pt = 1/72in, resulting in 1px = 72/96 pt.
+
+### To Enable
+
+To enable this hotfix (restore old behavior), supply a 'hotfixes' array to the options object in the jsPDF constructor function, and add the
+string 'px_scaling_legacy' to this array.
+
+# Accepted Hotfixes
+
 ## px_scaling
 
 ### Applies To
@@ -25,15 +44,10 @@ jsPDF Core
 ### Description
 
 When supplying 'px' as the unit for the PDF, the internal scaling factor was being miscalculated making drawn components
-larger than they should be. Enabling this hotfix will correct this scaling calculation and items will be drawn to the
-correct scale.
+larger than they should be. This hotfix corrected the scaling calculation so items are drawn to the correct scale.
 
-### To Enable
-
-To enable this hotfix, supply a 'hotfixes' array to the options object in the jsPDF constructor function, and add the
-string 'px_scaling' to this array.
-
-# Accepted Hotfixes
+This is now the default behavior as of the fix for issue #3921. The correct scaling (72/96) is used by default.
+For backward compatibility with the old incorrect scaling (96/72), use the 'px_scaling_legacy' hotfix.
 
 ## scale_text
 


### PR DESCRIPTION
## Problem

When using `unit: 'px'` with format strings (e.g., `format: 'a4'`), `doc.internal.pageSize.width` and `height` returned incorrect values due to an inverted scaling factor.

**Before (incorrect):**
const doc = new jsPDF({ unit: 'px', format: 'a4' });
console.log(doc.internal.pageSize.width);  // 446.46 (wrong)
console.log(doc.internal.pageSize.height);  // 631.42 (wrong)**After (correct):**
const doc = new jsPDF({ unit: 'px', format: 'a4' });
console.log(doc.internal.pageSize.width);  // 793.71 ✓
console.log(doc.internal.pageSize.height); // 1122.52 ✓## Root Cause

The default `scaleFactor` for px units was incorrectly set to `96/72` instead of `72/96`. According to CSS standards:
- 1px = 1/96in
- 1pt = 1/72in
- Therefore: 1px = 72/96 pt

The previous implementation used the inverse, causing all measurements to be incorrect.

## Solution

1. **Made correct px scaling the default**: Changed default `scaleFactor` from `96/72` to `72/96` for px units
2. **Backward compatibility**: Added `px_scaling_legacy` hotfix to restore old behavior if needed
3. **Updated documentation**: Updated `HOTFIX_README.md` and code comments to reflect the change

## Testing

✅ A4 format now correctly measures as 793.71 x 1122.52 px  
✅ All other units (mm, cm, in, pt) continue to work correctly  
✅ Backward compatibility maintained via `px_scaling_legacy` hotfix  
✅ Verified with multiple format sizes

## Breaking Changes

**None** - The fix corrects a bug. However, code that was relying on the incorrect behavior will now get correct values. If you need the old (incorrect) behavior for backward compatibility, you can use:

const doc = new jsPDF({ 
  unit: 'px', 
  format: 'a4',
  hotfixes: ['px_scaling_legacy'] 
});## Related Issue

Fixes #3921