### PR TITLE
fix: ensure separator boundary in allowFsRead wildcard check

### DIFF
--- a/src/modules/fileloading.js
+++ b/src/modules/fileloading.js
@@ -156,7 +156,7 @@ import { jsPDF } from "../jspdf.js";
         if (starIndex >= 0) {
           const fixedPart = allowedUrl.substring(0, starIndex);
           let resolved = path.resolve(fixedPart);
-          if (fixedPart.endsWith(path.sep) && !resolved.endsWith(path.sep)) {
+          if (!resolved.endsWith(path.sep)) {
             resolved += path.sep;
           }
           return url.startsWith(resolved);


### PR DESCRIPTION
This patch addresses the path prefix confusion in the allowFsRead wildcard handling reported via security disclosure.

The original condition checked whether fixedPart ended with path.sep before appending a separator to resolved. On Windows, path.sep is a backslash, but wildcard patterns are typically written with forward slashes (e.g. ./fonts/*), so the condition was never true and no separator was appended.

The fix removes the fixedPart check entirely. Since path.resolve() already normalizes the separator to the OS-native character, checking resolved alone is both sufficient and correct on all platforms.