### PR TITLE
Add configurable Producer metadata to address information disclosure (#3878)

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -1005,7 +1005,8 @@ function jsPDF(options) {
     subject: "",
     author: "",
     keywords: "",
-    creator: ""
+    creator: "",
+    producer: ""
   };
 
   API.__private__.getDocumentProperty = function(key) {
@@ -2856,9 +2857,14 @@ function jsPDF(options) {
       encryptor = encryption.encryptor(objectId, 0);
     }
     out("<<");
-    out("/Producer (" + pdfEscape(encryptor("jsPDF " + jsPDF.version)) + ")");
+    var producerValue = documentProperties.producer || "jsPDF " + jsPDF.version;
+    out("/Producer (" + pdfEscape(encryptor(producerValue)) + ")");
     for (var key in documentProperties) {
-      if (documentProperties.hasOwnProperty(key) && documentProperties[key]) {
+      if (
+        documentProperties.hasOwnProperty(key) &&
+        key !== "producer" &&
+        documentProperties[key]
+      ) {
         out(
           "/" +
             key.substr(0, 1).toUpperCase() +

--- a/test/specs/jspdf.unit.spec.js
+++ b/test/specs/jspdf.unit.spec.js
@@ -1302,7 +1302,8 @@ describe("Core: Unit Tests", () => {
       subject: "",
       author: "",
       keywords: "",
-      creator: ""
+      creator: "",
+      producer: ""
     });
 
     // expect(function() {doc.__private__.setDocumentProperty('invalid', 'Title');}).toThrow(new Error('Invalid arguments passed to jsPDF.setDocumentProperty'));
@@ -2914,6 +2915,46 @@ This is a test too.`,
       "/Author (Author X)",
       "/Keywords (Keyword1, Keyword2)",
       "/Creator (Creator)",
+      "/CreationDate (D:19871210000000+00'00')",
+      ">>",
+      "endobj"
+    ]);
+  });
+
+  it("jsPDF private function putInfo with custom producer", () => {
+    var doc = jsPDF({ floatPrecision: 2 });
+    var writeArray = [];
+    doc.__private__.setCustomOutputDestination(writeArray);
+    var pdfDateString = "D:19871210000000+00'00'";
+    doc.__private__.setCreationDate(pdfDateString);
+    doc.__private__.setDocumentProperty("producer", "Custom Producer v1.0");
+    doc.__private__.putInfo();
+    expect(writeArray).toEqual([
+      "3 0 obj",
+      "<<",
+      "/Producer (Custom Producer v1.0)",
+      "/CreationDate (D:19871210000000+00'00')",
+      ">>",
+      "endobj"
+    ]);
+  });
+
+  it("jsPDF private function putInfo with producer via setDocumentProperties", () => {
+    var doc = jsPDF({ floatPrecision: 2 });
+    var writeArray = [];
+    doc.__private__.setCustomOutputDestination(writeArray);
+    var pdfDateString = "D:19871210000000+00'00'";
+    doc.__private__.setCreationDate(pdfDateString);
+    doc.__private__.setDocumentProperties({
+      title: "Title",
+      producer: "My App v2.0"
+    });
+    doc.__private__.putInfo();
+    expect(writeArray).toEqual([
+      "3 0 obj",
+      "<<",
+      "/Producer (My App v2.0)",
+      "/Title (Title)",
       "/CreationDate (D:19871210000000+00'00')",
       ">>",
       "endobj"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -685,6 +685,7 @@ declare module "jspdf" {
     author?: string;
     keywords?: string;
     creator?: string;
+    producer?: string;
   }
 
   export interface PatternData {


### PR DESCRIPTION
Add configurable Producer metadata property

Allow users to override the PDF Producer field via `setDocumentProperties() `and `setDocumentProperty()` to address information disclosure concerns.

Usage:
```javascript
// Set custom producer
const doc = new jsPDF();
doc.setProperties({ producer: 'My Custom App v1.0' });

// Or via setDocumentProperty
doc.setDocumentProperty('producer', 'Custom Producer');

// Default behavior (unchanged) omit producer to get "jsPDF <version>"
const doc2 = new jsPDF();

```

Fixes #3878